### PR TITLE
Re-comment debug call to io:format in emysql_tcp.erl

### DIFF
--- a/src/emysql_tcp.erl
+++ b/src/emysql_tcp.erl
@@ -34,7 +34,7 @@
 -define(ETS_SELECT(TableID), ets:select(TableID,[{{'_','$2'},[],['$2']}])).
 
 send_and_recv_packet(Sock, Packet, SeqNum) ->
-	io:format("~nsend_and_receive_packet: SEND SeqNum: ~p, Binary: ~p~n", [SeqNum, <<(size(Packet)):24/little, SeqNum:8, Packet/binary>>]),
+	%-% io:format("~nsend_and_receive_packet: SEND SeqNum: ~p, Binary: ~p~n", [SeqNum, <<(size(Packet)):24/little, SeqNum:8, Packet/binary>>]),
 	%-% io:format("~p send_and_recv_packet: send~n", [self()]),
 	case gen_tcp:send(Sock, <<(size(Packet)):24/little, SeqNum:8, Packet/binary>>) of
 		ok -> 


### PR DESCRIPTION
This was introduced by accident in 287e17b2d350b5ae08f0a6243e1f2da508f72cd4

Makes using emysql a bit chatty :)
