### PR TITLE
Fix for Issue 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ encoding-test: all
 	(cd test; ct_run -suite latin_SUITE utf8_SUITE utf8_to_latindb_SUITE latin_to_utf8db_SUITE -pa ../ebin $(CRYPTO_PATH))
 
 test: all
-	(cd test; ct_run -suite environment_SUITE basics_SUITE -pa ../ebin $(CRYPTO_PATH))
+	(cd test; ct_run -suite environment_SUITE basics_SUITE conn_mgr_SUITE -pa ../ebin $(CRYPTO_PATH))
 
 test20: all
 	(cd test; ct_run -suite pool_SUITE -pa ../ebin $(CRYPTO_PATH))

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -1,3 +1,4 @@
+%% -*- mode: erlang;erlang-indent-level: 8;indent-tabs-mode:t -*-
 %% Copyright (c) 2009-2012
 %% Bill Warnecke <bill@rupture.com>
 %% Jacob Vorreuter <jacob.vorreuter@gmail.com>
@@ -74,10 +75,9 @@ wait_for_connection(PoolId)->
 	%% try to lock a connection. if no connections are available then
 	%% wait to be notified of the next available connection
     %-% io:format("~p waits for connection to pool ~p~n", [self(), PoolId]),
-	case lock_connection(PoolId) of
+        case do_gen_call({lock_connection_or_wait, PoolId}) of
 		unavailable ->
             %-% io:format("~p is queued~n", [self()]),
-			gen_server:call(?MODULE, {start_wait, PoolId}, infinity),
 			receive
 				{connection, Connection} -> 
                     %-% io:format("~p gets a connection after waiting in queue~n", [self()]),
@@ -184,12 +184,17 @@ handle_call({remove_connections, PoolId, Num}, _From, State) ->
 			{reply, {error, pool_not_found}, State}
 	end;
 
-handle_call({start_wait, PoolId}, {From, _Mref}, State) ->
+handle_call({lock_connection_or_wait, PoolId}, {From, _Mref}, State) ->
 	%% place to calling pid at the end of the waiting queue of its pool
 	case find_pool(PoolId, State#state.pools) of
 		{Pool, OtherPools} ->
-			PoolNow = Pool#pool{ waiting = queue:in(From, Pool#pool.waiting) },
-			{reply, ok, State#state{pools=[PoolNow|OtherPools]}};
+			case lock_next_connection(State, Pool, OtherPools) of
+				{ok, NewConn, State1} ->
+					{reply, NewConn, State1};
+				unavailable ->
+					PoolNow = Pool#pool{ waiting = queue:in(From, Pool#pool.waiting) },
+					{reply, unavailable, State#state{pools=[PoolNow|OtherPools]}}
+			end;
 		undefined ->
 			{reply, {error, pool_not_found}, State}
 	end;
@@ -197,16 +202,16 @@ handle_call({start_wait, PoolId}, {From, _Mref}, State) ->
 handle_call({lock_connection, PoolId}, _From, State) ->
 	%% find the next available connection in the pool identified by PoolId
     %-% io:format("gen srv: lock connection for pool ~p~n", [PoolId]),
-	case find_next_connection_in_pool(State#state.pools, PoolId) of
-		[Pool, OtherPools, Conn, OtherConns] ->
-            %-% io:format("gen srv: lock connection ... found a good next connection~n", []),
-			NewConn = Conn#emysql_connection{locked_at=lists:nth(2, tuple_to_list(now()))},
-			Locked = gb_trees:enter(NewConn#emysql_connection.id, NewConn, Pool#pool.locked),
-			State1 = State#state{pools = [Pool#pool{available=OtherConns, locked=Locked}|OtherPools]},
-			{reply, NewConn, State1};
-		Other ->
-            %-% io:format("gen srv: lock connection ... some other result: ~p~n", [Other]),
-			{reply, Other, State}
+	case find_pool(PoolId, State#state.pools) of
+		{Pool, OtherPools} ->
+			case lock_next_connection(State, Pool, OtherPools) of
+				{ok, NewConn, State1} ->
+					{reply, NewConn, State1};
+				Other ->
+					{reply, Other, State}
+			end;
+		undefined ->
+			{reply, {error, pool_not_found}, State}
 	end;
 
 handle_call({pass_connection, Connection}, _From, State) ->
@@ -315,20 +320,19 @@ find_pool(PoolId, [#pool{pool_id = PoolId} = Pool|Tail], OtherPools) ->
 find_pool(PoolId, [Pool|Tail], OtherPools) ->
 	find_pool(PoolId, Tail, [Pool|OtherPools]).
 
-find_next_connection_in_pool(Pools, PoolId) ->
-	case find_pool(PoolId, Pools) of
-		{Pool, OtherPools} ->
-		    % check no of connection in Pool
-		    %-% io:format("~p Pool ~p Connections available: ~p~n", [self(), PoolId, queue:len(Pool#pool.available)]),
-		    %-% io:format("~p Pool ~p Connections locked: ~p~n", [self(), PoolId, gb_trees:size(Pool#pool.locked)]),
-			case queue:out(Pool#pool.available) of
-				{{value, Conn}, OtherConns} ->
-					[Pool, OtherPools, Conn, OtherConns];
-				{empty, _} ->
-					unavailable
-			end;
-		undefined ->
-			{error, pool_not_found}
+lock_next_connection(State, Pool, OtherPools) ->
+	% check no of connection in Pool
+	%-% io:format("~p Pool ~p Connections available: ~p~n", [self(), PoolId, queue:len(Pool#pool.available)]),
+	%-% io:format("~p Pool ~p Connections locked: ~p~n", [self(), PoolId, gb_trees:size(Pool#pool.locked)]),
+	case queue:out(Pool#pool.available) of
+		{{value, Conn}, OtherConns} ->
+			%-% io:format("gen srv: lock connection ... found a good next connection~n", []),
+			NewConn = Conn#emysql_connection{locked_at=lists:nth(2, tuple_to_list(now()))},
+			Locked = gb_trees:enter(NewConn#emysql_connection.id, NewConn, Pool#pool.locked),
+			State1 = State#state{pools = [Pool#pool{available=OtherConns, locked=Locked}|OtherPools]},
+			{ok, Conn, State1};
+		{empty, _} ->
+			unavailable
 	end.
 
 %% This function does not wait, but may loop over the queue.
@@ -372,13 +376,13 @@ pass_on_or_queue_as_available(State, Connection) ->
    	    			PoolNow = Pool#pool{ waiting = OtherWaiting },
 			    	StateNow = State#state{ pools = [PoolNow|OtherPools] },
 
-		    	    case erlang:process_info(Pid, current_function) of
-			    	    {current_function,{emysql_conn_mgr,wait_for_connection,1}} ->
-				    	    erlang:send(Pid, {connection, Connection}),
-        			    	{ok, StateNow};
-    	    			_ ->
-	    	    		    % loop, to traverse queue to find a healthy candidate, until empty.
-	    	        		pass_on_or_queue_as_available(StateNow, Connection)
+				case erlang:is_process_alive(Pid) of
+					true ->
+						erlang:send(Pid, {connection, Connection}),
+						{ok, StateNow};
+					_ ->
+						% loop, to traverse queue to find a healthy candidate, until empty.
+						pass_on_or_queue_as_available(StateNow, Connection)
    			        end
             end;
 

--- a/test/basics_SUITE.erl
+++ b/test/basics_SUITE.erl
@@ -245,6 +245,6 @@ select_by_stored_procedure(_) ->
                         254,<<>>,33,60,0,0}],
                 	[[<<"Hello World!">>]],
                 	<<>>},
-			   {ok_packet,6,0,0,2,0,[]}],
+			   {ok_packet,6,0,0,34,0,[]}],
 	
 	ok.

--- a/test/conn_mgr_SUITE.erl
+++ b/test/conn_mgr_SUITE.erl
@@ -1,0 +1,65 @@
+%%%-------------------------------------------------------------------
+%%% File     : Emysql/test/conn_mgr_SUITE.erl
+%%% Descr    : Suite #7 - Testing connection manager. 
+%%% Author   : R. Richardson
+%%% Created  : 04/06/2012 ransomr
+%%% Requires : Erlang 14B (prior may not have ct_run)
+%%%-------------------------------------------------------------------
+%%%
+%%% Run from Emysql/: 
+%%%     make test
+%%%
+%%% Results see:
+%%%     test/index.html
+%%%
+%%%-------------------------------------------------------------------
+
+-module(conn_mgr_SUITE).
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("../include/emysql.hrl").
+
+% List of test cases.
+% Test cases have self explanatory names.
+%%--------------------------------------------------------------------
+all() -> 
+    [two_procs].
+
+
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+
+	% if this fails, focus on environment_SUITE to fix test setup.
+    crypto:start(),
+    application:start(emysql),
+    emysql:add_pool(test_pool, 1,
+        "hello_username", "hello_password", "localhost", 3306,
+        "hello_database", utf8),
+    Config.
+    
+% clean up
+%%--------------------------------------------------------------------
+end_per_suite(_) ->
+	ok.
+
+%% Test Case: Test two processes trying to share one connection
+%% Test for Issue 9
+%%--------------------------------------------------------------------
+two_procs(_) ->
+    Num = 2,
+    process_flag(trap_exit, true),
+    [spawn_link(fun test_proc/0)
+     || _ <- lists:seq(1,Num)],
+    [receive
+	 {'EXIT', _, Reason} -> 
+	     normal = Reason
+     end
+     || _ <- lists:seq(1,Num)],
+    ok.
+
+test_proc() ->
+    [
+     #result_packet{} = emysql:execute(test_pool, "describe hello_table;")
+     || _ <- lists:seq(1,1000)
+    ].
+     


### PR DESCRIPTION
This fixes three different race conditions when waiting for connections. The major changes are:
1. Combine locking and adding to the wait queue to one call so that there isn't a window in between.
2. After timeout have the waiting process remove itself from the wait queue. This removes the need to check if the process is still in wait_for_connection, which fixes the original problem reported in Issue 9. 
3. Handle race conditions with another process sending the waiting process that timed out a connection by checking if it was able to remove itself from the wait queue. If not, it knows someone else must have sent it a connection and waits for it. (Without this fix the connection would be lost from the pool).
4. Add tests for these issues.
