### PR TITLE
add support of utf8mb4 encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ install:
 all-test: test encoding-test test20
 
 encoding-test: all
-	(cd test; ct_run -suite latin_SUITE utf8_SUITE utf8_to_latindb_SUITE latin_to_utf8db_SUITE -pa ../ebin $(CRYPTO_PATH))
+	(cd test; ct_run -suite latin_SUITE utf8_SUITE utf8mb4_SUITE utf8_to_latindb_SUITE latin_to_utf8db_SUITE -pa ../ebin $(CRYPTO_PATH))
 
 test: all
 	(cd test; ct_run -suite environment_SUITE basics_SUITE conn_mgr_SUITE -pa ../ebin $(CRYPTO_PATH))

--- a/README.md
+++ b/README.md
@@ -341,7 +341,12 @@ For the encoding tests, please create these databases:
 	  use hello_utf8_database;
 	  create table hello_table (hello_text char(20));
 	  grant all privileges on hello_utf8_database.* to hello_username@localhost identified by 'hello_password';
-	  
+
+	  create database hello_utf8mb4_database character set utf8mb4;
+	  use hello_utf8mb4_database;
+	  create table hello_table (hello_text char(20));
+	  grant all privileges on hello_utf8mb4_database.* to hello_username@localhost identified by 'hello_password';
+
 	  create database hello_latin1_database character set latin1;
 	  use hello_latin1_database;
 	  create table hello_table (hello_text char(20));

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -322,8 +322,8 @@ decrement_pool_size(PoolId, Num) when is_integer(Num) ->
 %% 
 %% 	Result = emysql:execute(hello_pool, hello_stmt, ["Hello%"]),
 %% 
-%% 	 io:format("~n~s~n", [string:chars($-,72)]),
-%% 	 io:format("~p~n", [Result]),
+%% 	 error_logger:info_msg("~n~s~n", [string:chars($-,72)]),
+%% 	 error_logger:info_msg("~p~n", [Result]),
 %% 
 %%     ok.
 %% '''
@@ -465,9 +465,9 @@ execute(PoolId, StmtName, Timeout) when is_atom(StmtName), is_integer(Timeout) -
 %%
 
 execute(PoolId, Query, Args, Timeout) when (is_list(Query) orelse is_binary(Query)) andalso is_list(Args) andalso is_integer(Timeout) ->
-    %-% io:format("~p execute getting connection for pool id ~p~n",[self(), PoolId]),
+    %-% error_logger:info_msg("~p execute getting connection for pool id ~p~n",[self(), PoolId]),
 	Connection = emysql_conn_mgr:wait_for_connection(PoolId),
-    %-% io:format("~p execute got connection for pool id ~p: ~p~n",[self(), PoolId, Connection#emysql_connection.id]),
+    %-% error_logger:info_msg("~p execute got connection for pool id ~p: ~p~n",[self(), PoolId, Connection#emysql_connection.id]),
 	monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, Query, Args]});
 
 execute(PoolId, StmtName, Args, Timeout) when is_atom(StmtName), is_list(Args) andalso is_integer(Timeout) ->
@@ -571,7 +571,7 @@ monitor_work(Connection, Timeout, {M,F,A}) when is_record(Connection, emysql_con
 	Pid ! start,
 	receive
 		{'DOWN', Mref, process, Pid, {_, closed}} ->
-            %-% io:format("monitor_work: ~p DOWN/closed -> renew~n", [Pid]),
+            %-% error_logger:info_msg("monitor_work: ~p DOWN/closed -> renew~n", [Pid]),
 			case emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection, keep) of
 				NewConnection when is_record(NewConnection, emysql_connection) ->
 					%% re-loop, with new connection.
@@ -585,7 +585,7 @@ monitor_work(Connection, Timeout, {M,F,A}) when is_record(Connection, emysql_con
 			%% if the process dies, reset the connection
 			%% and re-throw the error on the current pid.
 			%% catch if re-open fails and also signal it.
-            %-% io:format("monitor_work: ~p DOWN ~p -> exit~n", [Pid, Reason]),
+            %-% error_logger:info_msg("monitor_work: ~p DOWN ~p -> exit~n", [Pid, Reason]),
 			case emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection, pass) of
 				{error,FailedReset} -> 
 					exit({Reason, {and_conn_reset_failed, FailedReset}});
@@ -595,14 +595,14 @@ monitor_work(Connection, Timeout, {M,F,A}) when is_record(Connection, emysql_con
 			%% if the process returns data, unlock the
 			%% connection and collect the normal 'DOWN'
 			%% message send from the child process
-            %-% io:format("monitor_work: ~p got result -> demonitor ~p, unlock connection ~p, return result~n", [Pid, Mref, Connection#emysql_connection.id]),
+            %-% error_logger:info_msg("monitor_work: ~p got result -> demonitor ~p, unlock connection ~p, return result~n", [Pid, Mref, Connection#emysql_connection.id]),
 			erlang:demonitor(Mref, [flush]),
 			emysql_conn_mgr:pass_connection(Connection),
 			Result
 		after Timeout ->
 			%% if we timeout waiting for the process to return,
 			%% then reset the connection and throw a timeout error
-            %-% io:format("monitor_work: ~p TIMEOUT -> demonitor, reset connection, exit~n", [Pid]),
+            %-% error_logger:info_msg("monitor_work: ~p TIMEOUT -> demonitor, reset connection, exit~n", [Pid]),
 			erlang:demonitor(Mref),
 			case emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection, pass) of
 				{error, FailedReset} -> 

--- a/src/emysql_app.erl
+++ b/src/emysql_app.erl
@@ -33,7 +33,7 @@ start(_Type, _StartArgs) ->
 
 	% case StartArgs of
 	%	"%MAKETIME%" -> ok; % happens with rebar build
-	%	_ -> io:format("Build time: ~p~n", StartArgs)
+	%	_ -> error_logger:info_msg("Build time: ~p~n", StartArgs)
 	% end,
 	
 	emysql_sup:start_link().

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -45,13 +45,13 @@ set_encoding(Connection, Encoding) ->
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).
 
 execute(Connection, Query, []) when is_list(Query) ->
-	 %-% io:format("~p execute list: ~p using connection: ~p~n", [self(), iolist_to_binary(Query), Connection#emysql_connection.id]),
+	 %-% error_logger:info_msg("~p execute list: ~p using connection: ~p~n", [self(), iolist_to_binary(Query), Connection#emysql_connection.id]),
 	Packet = <<?COM_QUERY, (emysql_util:to_binary(Query, Connection#emysql_connection.encoding))/binary>>,
 	% Packet = <<?COM_QUERY, (iolist_to_binary(Query))/binary>>,
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0);
 
 execute(Connection, Query, []) when is_binary(Query) ->
-	 %-% io:format("~p execute binary: ~p using connection: ~p~n", [self(), Query, Connection#emysql_connection.id]),
+	 %-% error_logger:info_msg("~p execute binary: ~p using connection: ~p~n", [self(), Query, Connection#emysql_connection.id]),
 	Packet = <<?COM_QUERY, Query/binary>>,
 	% Packet = <<?COM_QUERY, (iolist_to_binary(Query))/binary>>,
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0);
@@ -108,7 +108,7 @@ unprepare(Connection, Name) ->
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).
 
 open_n_connections(PoolId, N) ->
-	 %-% io:format("open ~p connections for pool ~p~n", [N, PoolId]),
+	 %-% error_logger:info_msg("open ~p connections for pool ~p~n", [N, PoolId]),
 	case emysql_conn_mgr:find_pool(PoolId, emysql_conn_mgr:pools()) of
 		{Pool, _} ->
 			lists:foldl(fun(_ ,Connections) ->
@@ -125,32 +125,32 @@ open_n_connections(PoolId, N) ->
 	end.
 
 open_connections(Pool) ->
-	 %-% io:format("open connections loop: .. "),
+	 %-% error_logger:info_msg("open connections loop: .. "),
 	case (queue:len(Pool#pool.available) + gb_trees:size(Pool#pool.locked)) < Pool#pool.size of
 		true ->
-	        %-% io:format(" continues~n"),
+	        %-% error_logger:info_msg(" continues~n"),
 			Conn = emysql_conn:open_connection(Pool),
-        	%-% io:format("opened connection: ~p~n", [Conn]),
+        	%-% error_logger:info_msg("opened connection: ~p~n", [Conn]),
 			open_connections(Pool#pool{available = queue:in(Conn, Pool#pool.available)});
 		false ->
-	        %-% io:format(" done~n"),
+	        %-% error_logger:info_msg(" done~n"),
 			Pool
 	end.
 
 open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=Password, database=Database, encoding=Encoding}) ->
-	 %-% io:format("~p open connection for pool ~p host ~p port ~p user ~p base ~p~n", [self(), PoolId, Host, Port, User, Database]),
-	 %-% io:format("~p open connection: ... connect ... ~n", [self()]),
+	 %-% error_logger:info_msg("~p open connection for pool ~p host ~p port ~p user ~p base ~p~n", [self(), PoolId, Host, Port, User, Database]),
+	 %-% error_logger:info_msg("~p open connection: ... connect ... ~n", [self()]),
 	case gen_tcp:connect(Host, Port, [binary, {packet, raw}, {active, false}]) of
 		{ok, Sock} ->
-			%-% io:format("~p open connection: ... got socket~n", [self()]),
+			%-% error_logger:info_msg("~p open connection: ... got socket~n", [self()]),
 			Mgr = whereis(emysql_conn_mgr),
 			Mgr /= undefined orelse
 				exit({failed_to_find_conn_mgr,
 					"Failed to find conn mgr when opening connection. Make sure crypto is started and emysql.app is in the Erlang path."}),
 			gen_tcp:controlling_process(Sock, Mgr),
-			%-% io:format("~p open connection: ... greeting~n", [self()]),
+			%-% error_logger:info_msg("~p open connection: ... greeting~n", [self()]),
 			Greeting = emysql_auth:do_handshake(Sock, User, Password),
-			%-% io:format("~p open connection: ... make new connection~n", [self()]),
+			%-% error_logger:info_msg("~p open connection: ... make new connection~n", [self()]),
 			Connection = #emysql_connection{
 				id = erlang:port_to_list(Sock),
 				pool_id = PoolId,
@@ -161,30 +161,30 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
 				caps = Greeting#greeting.caps,
 				language = Greeting#greeting.language
 			},
-			%-% io:format("~p open connection: ... set db ...~n", [self()]),
+			%-% error_logger:info_msg("~p open connection: ... set db ...~n", [self()]),
 			case emysql_conn:set_database(Connection, Database) of
 				OK1 when is_record(OK1, ok_packet) ->
-					 %-% io:format("~p open connection: ... db set ok~n", [self()]),
+					 %-% error_logger:info_msg("~p open connection: ... db set ok~n", [self()]),
 					ok;
 				Err1 when is_record(Err1, error_packet) ->
-					 %-% io:format("~p open connection: ... db set error~n", [self()]),
+					 %-% error_logger:info_msg("~p open connection: ... db set error~n", [self()]),
 					exit({failed_to_set_database, Err1#error_packet.msg})
 			end,
-			%-% io:format("~p open connection: ... set encoding ...: ~p~n", [self(), Encoding]),
+			%-% error_logger:info_msg("~p open connection: ... set encoding ...: ~p~n", [self(), Encoding]),
 			case emysql_conn:set_encoding(Connection, Encoding) of
 				OK2 when is_record(OK2, ok_packet) ->
 					ok;
 				Err2 when is_record(Err2, error_packet) ->
 					exit({failed_to_set_encoding, Err2#error_packet.msg})
 			end,
-			 %-% io:format("~p open connection: ... ok, return connection~n", [self()]),
+			 %-% error_logger:info_msg("~p open connection: ... ok, return connection~n", [self()]),
 			Connection;
 		{error, Reason} ->
-			 %-% io:format("~p open connection: ... ERROR ~p~n", [self(), Reason]),
-			 %-% io:format("~p open connection: ... exit with failed_to_connect_to_database~n", [self()]),
+			 %-% error_logger:info_msg("~p open connection: ... ERROR ~p~n", [self(), Reason]),
+			 %-% error_logger:info_msg("~p open connection: ... exit with failed_to_connect_to_database~n", [self()]),
 			exit({failed_to_connect_to_database, Reason});
 		What ->
-			 %-% io:format("~p open connection: ... UNKNOWN ERROR ~p~n", [self(), What]),
+			 %-% error_logger:info_msg("~p open connection: ... UNKNOWN ERROR ~p~n", [self(), What]),
 			exit({unknown_fail, What})
 	end.
 
@@ -196,26 +196,26 @@ reset_connection(Pools, Conn, StayLocked) ->
 	%% we queue the old as available for the next try
 	%% by the next caller process coming along. So the
 	%% pool can't run dry, even though it can freeze.
-	%-% io:format("resetting connection~n"),
-	%-% io:format("spawn process to close connection~n"),
+	%-% error_logger:info_msg("resetting connection~n"),
+	%-% error_logger:info_msg("spawn process to close connection~n"),
 	spawn(fun() -> close_connection(Conn) end),
 	%% OPEN NEW SOCKET
 	case emysql_conn_mgr:find_pool(Conn#emysql_connection.pool_id, Pools) of
 		{Pool, _} ->
-			%-% io:format("... open new connection to renew~n"),
+			%-% error_logger:info_msg("... open new connection to renew~n"),
 			case catch open_connection(Pool) of
 				NewConn when is_record(NewConn, emysql_connection) ->
-					%-% io:format("... got it, replace old (~p)~n", [StayLocked]),
+					%-% error_logger:info_msg("... got it, replace old (~p)~n", [StayLocked]),
 					case StayLocked of
 						pass -> emysql_conn_mgr:replace_connection_as_available(Conn, NewConn);
 						keep -> emysql_conn_mgr:replace_connection_as_locked(Conn, NewConn)
 					end,
-					%-% io:format("... done, return new connection~n"),
+					%-% error_logger:info_msg("... done, return new connection~n"),
 					NewConn;
 				Error ->
 					DeadConn = Conn#emysql_connection{alive=false},
 					emysql_conn_mgr:replace_connection_as_available(Conn, DeadConn),
-					%-% io:format("... failed to re-open. Shelving dead connection as available.~n"),
+					%-% error_logger:info_msg("... failed to re-open. Shelving dead connection as available.~n"),
 					{error, {cannot_reopen_in_reset, Error}}
 			end;
 		undefined ->

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -218,12 +218,11 @@ handle_call({end_wait, PoolId}, {From, _Mref}, State) ->
 			%% See if the length changed to know if From was removed.
 			OldLen = queue:len(Pool#pool.waiting),
 			NewLen = queue:len(QueueNow),
-			if
-				OldLen =:= NewLen ->
-					Reply = not_waiting;
-				true ->
-					Reply = ok
-			end,
+			Reply = if OldLen =:= NewLen ->
+                        not_waiting;
+                    true ->
+                        ok
+                    end,
 			{reply, Reply, State#state{pools=[PoolNow|OtherPools]}};
 		undefined ->
 			{reply, {error, pool_not_found}, State}

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -351,8 +351,8 @@ find_pool(PoolId, [Pool|Tail], OtherPools) ->
 
 lock_next_connection(State, Pool, OtherPools) ->
 	% check no of connection in Pool
-	%-% error_logger:info_msg("~p Pool ~p Connections available: ~p~n", [self(), PoolId, queue:len(Pool#pool.available)]),
-	%-% error_logger:info_msg("~p Pool ~p Connections locked: ~p~n", [self(), PoolId, gb_trees:size(Pool#pool.locked)]),
+	%-% error_logger:info_msg("~p Pool ~p Connections available: ~p~n", [self(), Pool#pool.pool_id, queue:len(Pool#pool.available)]),
+	%-% error_logger:info_msg("~p Pool ~p Connections locked: ~p~n", [self(), Pool#pool.pool_id, gb_trees:size(Pool#pool.locked)]),
 	case queue:out(Pool#pool.available) of
 		{{value, Conn}, OtherConns} ->
 			%-% error_logger:info_msg("gen srv: lock connection ... found a good next connection~n", []),

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -74,16 +74,16 @@ lock_connection(PoolId)->
 wait_for_connection(PoolId)->
 	%% try to lock a connection. if no connections are available then
 	%% wait to be notified of the next available connection
-    %-% io:format("~p waits for connection to pool ~p~n", [self(), PoolId]),
+    %-% error_logger:info_msg("~p waits for connection to pool ~p~n", [self(), PoolId]),
         case do_gen_call({lock_connection_or_wait, PoolId}) of
 		unavailable ->
-            %-% io:format("~p is queued~n", [self()]),
+            %-% error_logger:info_msg("~p is queued~n", [self()]),
 			receive
 				{connection, Connection} -> 
-                    %-% io:format("~p gets a connection after waiting in queue~n", [self()]),
+                    %-% error_logger:info_msg("~p gets a connection after waiting in queue~n", [self()]),
     				Connection
 			after lock_timeout() ->
-                %-% io:format("~p gets no connection and times out -> EXIT~n~n", [self()]),
+                %-% error_logger:info_msg("~p gets no connection and times out -> EXIT~n~n", [self()]),
 				case do_gen_call({end_wait, PoolId}) of
 					ok ->
 						exit(connection_lock_timeout);
@@ -95,7 +95,7 @@ wait_for_connection(PoolId)->
 				end
 			end;
 		Connection ->
-            %-% io:format("~p gets connection~n", [self()]),
+            %-% error_logger:info_msg("~p gets connection~n", [self()]),
 			Connection
 	end.
 
@@ -231,7 +231,7 @@ handle_call({end_wait, PoolId}, {From, _Mref}, State) ->
 
 handle_call({lock_connection, PoolId}, _From, State) ->
 	%% find the next available connection in the pool identified by PoolId
-    %-% io:format("gen srv: lock connection for pool ~p~n", [PoolId]),
+    %-% error_logger:info_msg("gen srv: lock connection for pool ~p~n", [PoolId]),
 	case find_pool(PoolId, State#state.pools) of
 		{Pool, OtherPools} ->
 			case lock_next_connection(State, Pool, OtherPools) of
@@ -352,11 +352,11 @@ find_pool(PoolId, [Pool|Tail], OtherPools) ->
 
 lock_next_connection(State, Pool, OtherPools) ->
 	% check no of connection in Pool
-	%-% io:format("~p Pool ~p Connections available: ~p~n", [self(), PoolId, queue:len(Pool#pool.available)]),
-	%-% io:format("~p Pool ~p Connections locked: ~p~n", [self(), PoolId, gb_trees:size(Pool#pool.locked)]),
+	%-% error_logger:info_msg("~p Pool ~p Connections available: ~p~n", [self(), PoolId, queue:len(Pool#pool.available)]),
+	%-% error_logger:info_msg("~p Pool ~p Connections locked: ~p~n", [self(), PoolId, gb_trees:size(Pool#pool.locked)]),
 	case queue:out(Pool#pool.available) of
 		{{value, Conn}, OtherConns} ->
-			%-% io:format("gen srv: lock connection ... found a good next connection~n", []),
+			%-% error_logger:info_msg("gen srv: lock connection ... found a good next connection~n", []),
 			NewConn = Conn#emysql_connection{locked_at=lists:nth(2, tuple_to_list(now()))},
 			Locked = gb_trees:enter(NewConn#emysql_connection.id, NewConn, Pool#pool.locked),
 			State1 = State#state{pools = [Pool#pool{available=OtherConns, locked=Locked}|OtherPools]},
@@ -422,11 +422,11 @@ lock_timeout() ->
 receive_connection_not_waiting() ->
 	receive
 		{connection, Connection} -> 
-			%%-% io:format("~p gets a connection after timeout in queue~n", [self()]),
+			%%-% error_logger:info_msg("~p gets a connection after timeout in queue~n", [self()]),
 			Connection
 	after 
 		%% This should never happen, as we should only be here if we had been sent a connection
 		lock_timeout() ->
-			%%-% io:format("~p gets no connection and times out again -> EXIT~n~n", [self()]),
+			%%-% error_logger:info_msg("~p gets no connection and times out again -> EXIT~n~n", [self()]),
 			exit(connection_lock_second_timeout)
 	end.

--- a/src/emysql_tracer.erl
+++ b/src/emysql_tracer.erl
@@ -30,15 +30,15 @@ do_trace(Parent, Fun) ->
 trace_loop() ->
 	receive
 		%{trace, _, call, X} ->
-		%	io:format("Call: ~p~n", [X]),
+		%	error_logger:info_msg("Call: ~p~n", [X]),
 		%	trace_loop();
 		%{trace, _, return_from, Call, Ret} ->
-		%	io:format("Return From: ~p => ~p~n", [Call, Ret]),
+		%	error_logger:info_msg("Return From: ~p => ~p~n", [Call, Ret]),
 		%	trace_loop();
 		%{trace, _, send_to_non_existing_process, Msg, To} ->
-		%	io:format("send_to_non_existing_process ~p to ~p~n", [Msg, To]),
+		%	error_logger:info_msg("send_to_non_existing_process ~p to ~p~n", [Msg, To]),
 		%	trace_loop();
 		_Other ->
-			io:format("~p~n", [_Other]),
+			error_logger:info_msg("~p~n", [_Other]),
 			trace_loop()
 	end.

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -199,9 +199,9 @@ encode(Val, binary, Encoding) when is_list(Val) ->
 
 
 encode(Val, binary, latin1) when is_binary(Val) ->
-	%-% io:format("encode latin-1 in : ~s = ~w ~n", [Val, Val]),
+	%-% error_logger:info_msg("encode latin-1 in : ~s = ~w ~n", [Val, Val]),
 	X = list_to_binary(quote(binary_to_list(Val))),
-	%-% io:format("encode latin-1 out: ~s = ~w ~n", [X, X]),
+	%-% error_logger:info_msg("encode latin-1 out: ~s = ~w ~n", [X, X]),
 	X;
 	
 encode(Val, binary, utf8mb4) when is_binary(Val) ->
@@ -216,8 +216,8 @@ encode(Val, binary, Encoding) when is_binary(Val) ->
     end;
 
 encode(Val, list, _) when is_list(Val) ->
-	%-% io:format("encode list in : ~s = ~w ~n", [Val, Val]),
-	%-% io:format("encode list out: ~s = ~w ~n", [quote(Val), quote(Val)]),
+	%-% error_logger:info_msg("encode list in : ~s = ~w ~n", [Val, Val]),
+	%-% error_logger:info_msg("encode list out: ~s = ~w ~n", [quote(Val), quote(Val)]),
 	quote(Val);
 
 encode(Val, list, _) when is_integer(Val) ->

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -181,12 +181,18 @@ encode(undefined, binary, _)  ->
 encode(Val, list, latin1) when is_binary(Val) ->
 	quote(binary_to_list(Val));
 
+encode(Val, list, utf8mb4) when is_binary(Val) ->
+    encode(Val, list, utf8);
+
 encode(Val, list, Encoding) when is_binary(Val) ->
 	quote(unicode:characters_to_list(Val, Encoding));
 
 
 encode(Val, binary, latin1) when is_list(Val) -> 
 	list_to_binary(quote(Val));
+
+encode(Val, binary, utf8mb4) when is_list(Val) ->
+    encode(Val, binary, utf8);
 
 encode(Val, binary, Encoding) when is_list(Val) ->
 	unicode:characters_to_binary(quote(Val), Encoding, Encoding);
@@ -198,6 +204,9 @@ encode(Val, binary, latin1) when is_binary(Val) ->
 	%-% io:format("encode latin-1 out: ~s = ~w ~n", [X, X]),
 	X;
 	
+encode(Val, binary, utf8mb4) when is_binary(Val) ->
+    encode(Val, binary, utf8);
+
 encode(Val, binary, Encoding) when is_binary(Val) ->
 	case unicode:characters_to_list(Val,Encoding) of
 		{error,E1,E2} -> exit({invalid_utf8_binary, E1, E2});
@@ -353,6 +362,9 @@ to_binary(L,_) when is_binary(L) ->
 	
 to_binary(L,latin1) when is_list(L) ->
 	list_to_binary(L);
+
+to_binary(L,utf8mb4) when is_list(L) ->
+    to_binary(L,utf8);
 
 to_binary(L,Encoding) when is_list(L) ->
 	unicode:characters_to_binary(L,Encoding,Encoding).

--- a/test/utf8mb4_SUITE.erl
+++ b/test/utf8mb4_SUITE.erl
@@ -1,0 +1,1188 @@
+%%%-------------------------------------------------------------------
+%%% File     : Emysql/test/utf8_SUITE.erl
+%%% Descr    : Suite #3: Test for UTF-8 connection to UTF-8 DB.
+%%% Author   : H. Diedrich
+%%% Created  : 12/14/2011 hd
+%%% Changed  : 03/26/2012 hd
+%%% Requires : Erlang 14B (prior may not have ct_run)
+%%%-------------------------------------------------------------------
+%%%
+%%% Run from Emysql/: 
+%%%     make test
+%%%
+%%% Results see:
+%%%     test/index.html
+%%%
+%%%-------------------------------------------------------------------
+
+-module(utf8mb4_SUITE).
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+
+-record(hello_record, {hello_text}).
+
+%% Optional suite settings
+%%--------------------------------------------------------------------
+%% Function: suite() -> Info
+%% Info = [tuple()]
+%%--------------------------------------------------------------------
+
+suite() ->
+    [{timetrap,{seconds,60}}].
+
+%% Mandatory list of test cases and test groups, and skip orders. 
+%%--------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases | {skip,Reason}
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%% TestCase = atom()
+%% Reason = term()
+%%--------------------------------------------------------------------
+
+all() -> 
+    [delete_all,
+     insert_only,
+	 insert_only_unicode_binary,
+	 insert_only_unicode_liststring,
+	 insert_and_read_back_as_recs,
+	 select_by_prepared_statement,
+
+	 % these tests are easiest to read
+     straighttalk_write_binary_latin1_directly,
+     straighttalk_write_binary_latin1_with_special_char_directly,
+     straighttalk_write_binary_unicode_directly,
+     straighttalk_write_liststring_latin1_directly,
+     straighttalk_write_liststring_unicode_directly,
+     straighttalk_write_liststring_latin1_with_special_char_directly,
+     straighttalk_write_binary_latin1_via_statement, 
+     straighttalk_write_binary_latin1_with_special_char_via_statement,
+     straighttalk_write_binary_unicode_via_statement,
+     straighttalk_write_binary_all_latin1_as_unicode_via_statement,
+     straighttalk_write_liststring_latin1_via_statement,
+     straighttalk_write_liststring_unicode_via_statement,
+	 
+	 % these are tests using nested worker functions
+	 test_read_back_directly_function,
+	 test_read_back_by_statement_function,
+	 test_stmt_and_read_back_directly_function,
+	 test_stmt_and_read_back_stmt_function,
+	 test_latin1_binary_direct,
+	 test_latin1_binary_via_parameter,
+	 test_latin1_liststring_via_parameter,
+	 test_latin1_binary,
+	 test_latin1_liststring,
+	 test_unicode_binary,
+	 test_unicode_liststring,
+	 
+	 test_latin1_quote_as_binary,
+	 test_latin1_quote_as_liststring,
+	 test_unicode_quote_as_binary,
+	 test_unicode_quote_as_liststring,
+	 test_latin1_quote_and_text_as_binary,
+	 test_latin1_quote_and_text_as_liststring,
+	 test_unicode_quote_and_text_as_binary,
+	 test_unicode_quote_and_text_as_liststring,
+	 test_latin1_quote_and_trailing_text_as_binary,
+	 test_latin1_quote_and_trailing_text_as_liststring,
+	 test_unicode_quote_and_trailing_text_as_binary,
+	 test_unicode_quote_and_trailing_text_as_liststring,
+	 
+	 test_worker_quartet_single_functions,
+	 test_worker_quartet,
+	 test_escaping,
+     test_escaping_with_non_latin1,
+	 test_escaping_with_non_latin1_leading_umlaut
+	 ].
+
+%% Optional suite pre test initialization
+%%--------------------------------------------------------------------
+%% Function: init_per_suite(Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+
+	% if this fails, focus on environment_SUITE to fix test setup.
+    crypto:start(),
+    application:start(emysql),
+    emysql:add_pool(test_pool, 1,
+        "hello_username", "hello_password", "localhost", 3306,
+        "hello_utf8mb4_database", utf8mb4),
+
+	emysql:prepare(stmt_insert, 
+		<<"INSERT INTO hello_table SET hello_text = ?">>),
+
+	emysql:prepare(stmt_select, 
+		<<"SELECT * FROM hello_table">>),
+
+    Config.
+
+%% Optional suite post test wind down
+%%--------------------------------------------------------------------
+%% Function: end_per_suite(Config0) -> void() | {save_config,Config1}
+%% Config0 = Config1 = [tuple()]
+%%--------------------------------------------------------------------
+
+end_per_suite(_Config) ->
+	emysql:remove_pool(test_pool),
+    ok.
+
+%%--------------------------------------------------------------------
+%%
+%% Human Understandable ('straighttalk') Tests.
+%%
+%%--------------------------------------------------------------------
+%% These tests are the easiest to read.
+%% They also serve to make sure that at least some tests don't
+%% completely miss the point for cleverness.
+
+straighttalk_write_binary_latin1_directly(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		<<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	String = <<"Hello World!">>,
+    % in = out
+
+    ok.
+
+straighttalk_write_binary_latin1_with_special_char_directly(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		<<"INSERT INTO hello_table SET hello_text = 'Hello Wørld!'">>),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	<<"Hello W">> = String, 
+    % in /= out:
+    % The UTF-8 database truncated as a ø in Latin-1 is an invalid bit pattern.
+
+    ok.
+
+
+straighttalk_write_binary_unicode_directly(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		<<"INSERT INTO hello_table SET hello_text = 'Hello Wørld!'"/utf8>>),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	String = <<"Hello Wørld!"/utf8>>,
+    % in = out
+
+    ok.
+
+
+straighttalk_write_liststring_latin1_directly(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		"INSERT INTO hello_table SET hello_text = 'Hello World!'"),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	String = <<"Hello World!">>,
+    % in = out
+	% note: returns are always binaries.
+
+    ok.
+
+
+straighttalk_write_liststring_unicode_directly(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		unicode:characters_to_list( % (*)
+		<<"INSERT INTO hello_table SET hello_text = 'Hello Wørld!'"/utf8>>)),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	 <<"Hello Wørld!"/utf8>> = String,
+    % in = out
+	% note: returns are always binaries.
+	
+	Same = unicode:characters_to_list(
+		<<"INSERT INTO hello_table SET hello_text = 'Hello Wørld!'"/utf8>>),
+	Same = binary_to_list(
+		<<"INSERT INTO hello_table SET hello_text = 'Hello Wørld!'">>),
+
+    ok.
+
+
+straighttalk_write_liststring_latin1_with_special_char_directly(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		"INSERT INTO hello_table SET hello_text = 'Hello Wørld!'"),
+		% note: automatically made utf8
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	<<"Hello Wørld!"/utf8>> = String,
+    % in = out:
+	% automatic conversion by driver for connection set to utf8.
+	% note: returns are always binaries.
+
+    ok.
+
+straighttalk_write_binary_latin1_via_statement(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [<<"Hello World!">>]),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	String = <<"Hello World!">>,
+    % in = out
+
+    ok.
+
+straighttalk_write_binary_latin1_with_special_char_via_statement(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+    try
+    	emysql:execute(test_pool, stmt_insert, [<<"Hello Wørld!">>]),
+  	    exit(should_have_crashed)
+    catch
+       exit:{{invalid_utf8_binary,"Hello W",<<"ørld!">>}, {}} -> ok
+    end,
+
+    ok.
+
+straighttalk_write_binary_unicode_via_statement(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [<<"Hello Wørld!"/utf8>>]),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	<<"Hello Wørld!"/utf8>> = String,
+    % in = out
+
+    ok.
+
+
+straighttalk_write_binary_all_latin1_as_unicode_via_statement(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [<<"Hello World!"/utf8>>]),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	String = <<"Hello World!"/utf8>>,
+    % in = out
+
+    ok.
+
+
+straighttalk_write_liststring_latin1_via_statement(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, ["Hello World!"]),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+	String = <<"Hello World!">>,
+    % in = out
+	% note: returns are always binaries.
+
+    ok.
+
+
+straighttalk_write_liststring_unicode_via_statement(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [unicode:characters_to_list(<<"Hello Wørld!"/utf8>>,utf8)]), % (*)
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	[{hello_record, String}] = Recs,
+
+    % N.B.
+	<<"Hello Wørld!">> = list_to_binary(unicode:characters_to_list(<<"Hello Wørld!"/utf8>>)),
+	% the code point of ø is the same for Unicode and Latin-1
+	% even thought the bitpattern of UTF-8 and Latin-1 is not.
+	% But unicode:characters_to_list/1/2 delivers codepoints,
+	% not binary bitpatterns.
+
+	 <<"Hello Wørld!"/utf8>> = String,
+    % in = out
+	% note: returns are always binaries.
+    ok.
+
+ 
+
+%%--------------------------------------------------------------------
+%%
+%% Preliminary Tests of basic functionality.
+%%
+%%--------------------------------------------------------------------
+
+
+%% A test case. The ok is irrelevant. What matters is, if it returns.
+%%--------------------------------------------------------------------
+%% Function: TestCase(Config0) ->
+%%               ok | exit() | {skip,Reason} | {comment,Comment} |
+%%               {save_config,Config1} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% Comment = term()
+%%--------------------------------------------------------------------
+
+%% Test Case: Delete all records in the test database
+%%--------------------------------------------------------------------
+delete_all(_) ->
+	
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+    ok.
+
+
+%% Test Case: Make an Insert
+%%--------------------------------------------------------------------
+insert_only(_) ->
+	
+    emysql:execute(test_pool,
+        <<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
+
+    ok.
+
+%% Test Case: Make an Insert
+%%--------------------------------------------------------------------
+insert_only_unicode_binary(_) ->
+	
+    emysql:execute(test_pool,
+        <<"INSERT INTO hello_table SET hello_text = 'Hello Wørld!'"/utf8>>),
+
+    ok.
+
+%% Test Case: Make an Insert
+%%--------------------------------------------------------------------
+insert_only_unicode_liststring(_) ->
+	
+    emysql:execute(test_pool,
+    	unicode:characters_to_list(
+        <<"INSERT INTO hello_table SET hello_text = 'Hellö Wørld!'"/utf8>>)),
+
+    ok.
+
+%% Test Case: Make an Insert and Select it back, reading out as Record
+%%--------------------------------------------------------------------
+insert_and_read_back_as_recs(_) ->
+	
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		<<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Result: ~p~n", [Result]),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Recs: ~p~n", [Recs]),
+
+	% the test
+	Recs = [{hello_record,<<"Hello World!">>}],
+
+	ok.
+	
+
+%% Test Case: Create a Prepared Statement and make a Select with it
+%%--------------------------------------------------------------------
+select_by_prepared_statement(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		<<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
+
+	emysql:prepare(test_stmt, 
+		<<"SELECT * from hello_table WHERE hello_text like ?">>),
+
+	Result = emysql:execute(test_pool, test_stmt, ["Hello%"]),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Result: ~p~n", [Result]),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Recs: ~p~n", [Recs]),
+
+	% the test
+	Recs = [{hello_record,<<"Hello World!">>}],
+
+	[{hello_record,BinString}] = Recs,
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Result String (latin-1 string): ~ts~n", [BinString]),
+
+	% the test
+	BinString = <<"Hello World!">>,
+
+    ok.
+
+
+%%--------------------------------------------------------------------
+%%
+%% Workers and tests of workers.
+%%
+%%--------------------------------------------------------------------
+
+
+%% Worker: Read back and check, using SELECT directly
+%%--------------------------------------------------------------------
+%% Note: coming back from the database is always a binary.
+
+read_back_directly(Value) when is_list(Value) ->
+	read_back_directly(list_to_binary(Value)); % will this break with codepoints > Latin-1?
+	
+read_back_directly(Value) when is_binary(Value) ->
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
+	% io:format("                           expecting (unicode): ~ts~n", [Value]),
+	io:format("                           expecting (integer): ~w~n", [Value]),
+
+	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Result: ~p~n", [Result]),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Recs: ~p~n", [Recs]),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	[{hello_record, ResultBin}] = Recs,
+   	io:format("Result String: ~w~n", [ResultBin]),
+
+	% the test
+ 	Value = ResultBin,
+
+    ok.
+
+
+%% Worker: Read back and check, using SELECT by prepared statement
+%%--------------------------------------------------------------------
+%% Note: coming back from the database is always a binary.
+
+read_back_by_statement(Value) when is_list(Value) ->
+	read_back_by_statement(list_to_binary(Value));
+
+read_back_by_statement(Value) when is_binary(Value) ->
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
+	
+	io:format("                                        expecting (integer): ~w~n", [Value]),
+
+	Result = emysql:execute(test_pool, stmt_select),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Result: ~p~n", [Result]),
+
+	Recs = emysql_util:as_record(
+		Result, hello_record, record_info(fields, hello_record)),
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	io:format("Recs: ~p~n", [Recs]),
+
+	% the test
+	Recs = [{hello_record, Value}],
+
+
+	% find this output by clicking on the test name, then case name in test/index.html
+	[{hello_record,BinString}] = Recs,
+	io:format("Result String: ~w~n", [BinString]),
+
+	% the test
+	BinString = Value,
+
+    ok.
+
+
+%% Test Case: Write and read back a binary. This tests the worker function.
+%%--------------------------------------------------------------------
+test_read_back_directly_function(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		<<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
+
+	read_back_directly(<<"Hello World!">>),
+	read_back_directly("Hello World!"),
+
+    ok.
+
+%% Test Case: Write and read back. This tests the select statement.
+%%--------------------------------------------------------------------
+test_read_back_by_statement_function(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		<<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
+
+	read_back_by_statement(<<"Hello World!">>),
+	read_back_by_statement("Hello World!"),
+
+    ok.
+
+%% Test Case: Write and read back. This tests the insert statement.
+%%--------------------------------------------------------------------
+test_stmt_and_read_back_directly_function(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [<<"Hello World!">>]),
+	read_back_directly(<<"Hello World!">>),
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, ["Hello World!"]),
+	read_back_directly(<<"Hello World!">>),
+
+    ok.
+
+%% Test Case: Write and read back. This tests both statements.
+%%--------------------------------------------------------------------
+test_stmt_and_read_back_stmt_function(_) ->
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [<<"Hello World!">>]),
+	read_back_by_statement(<<"Hello World!">>),
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, ["Hello World!"]),
+	read_back_by_statement(<<"Hello World!">>),
+
+    ok.
+
+
+%% Test Case: Latin 1 binary as direct insert statement.
+%%--------------------------------------------------------------------
+test_latin1_binary_direct(_) ->
+
+	Value = <<"Hello World X!">>,
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		unicode:characters_to_binary(["INSERT INTO hello_table SET hello_text = ",
+			emysql_util:quote(Value,latin1)])),
+
+	read_back_directly(Value),
+	read_back_by_statement(Value),
+
+    ok.
+
+
+%% Test Case: Latin 1 binary as parameter to prepared insert statement.
+%%--------------------------------------------------------------------
+test_latin1_binary_via_parameter(_) ->
+
+	Value = <<"Hello World XX!">>,
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [Value]),
+
+	read_back_directly(Value),
+	read_back_by_statement(Value),
+
+    ok.
+
+
+%% Test Case: Latin 1 liststring as parameter to prepared insert statement.
+%%--------------------------------------------------------------------
+test_latin1_liststring_via_parameter(_) ->
+
+	Value = "Hello World XXX!",
+	Binary = unicode:characters_to_binary(Value),
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [Value]),
+
+	read_back_directly(Binary),
+	read_back_by_statement(Binary),
+
+    ok.
+
+
+%% Worker: write binary as direct insert statement.
+%%--------------------------------------------------------------------
+worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
+
+	io:format("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
+	io:format("******************************************~n", []),
+
+	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
+
+	X = emysql_util:any_to_binary(["INSERT INTO hello_table SET hello_text = ",
+			emysql_util:quote(Value,QuoteEncoding)]),
+
+	io:format("=> ~p = ~w.~n", [X,X]),
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool,
+		emysql_util:any_to_binary(["INSERT INTO hello_table SET hello_text = ",
+			emysql_util:quote(Value,QuoteEncoding)])),
+
+	read_back_directly(Expect),
+	read_back_by_statement(Expect),
+
+    ok.
+
+%% Worker: write liststring as direct insert statement.
+%%--------------------------------------------------------------------
+worker_direct_insert(Value, Binary) when is_list(Value) ->
+
+	io:format("Worker: write liststring as direct insert statement.~n", []),
+	io:format("**********************************************~n", []),
+
+	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
+
+	io:format("Binary: ~p = ~w.~n", [Binary,Binary]),
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, "INSERT INTO hello_table SET hello_text = " ++ 
+	    emysql_util:quote(Value)),
+
+	read_back_directly(Binary),
+	read_back_by_statement(Binary),
+
+    ok.
+
+
+%% Worker: write binary as parameter to prepared insert statement.
+%%--------------------------------------------------------------------
+worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
+
+	io:format("Worker: write binary as parameter to prepared insert statement.~n", []),
+	io:format("*********************************************************~n", []),
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [Value]),
+
+	io:format("... read back directly~n", []),
+
+	read_back_directly(Expect),
+
+	io:format("... read back via statement~n", []),
+
+	read_back_by_statement(Expect),
+
+    ok.
+    
+%% Worker: write liststring as parameter to prepared insert statement.
+%%--------------------------------------------------------------------
+worker_insert_via_statement(Value,Binary) when is_list(Value) ->
+
+	io:format("Worker: write liststring as parameter to prepared insert statement.~n", []),
+	io:format("*************************************************************~n", []),
+
+    emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
+
+	emysql:execute(test_pool, stmt_insert, [Value]),
+
+	io:format("... read back directly~n", []),
+
+	read_back_directly(Binary),
+
+	io:format("... read back via statement~n", []),
+
+	read_back_by_statement(Binary),
+
+    ok.
+
+
+%% Worker Test Case: Latin 1 binary.
+%%--------------------------------------------------------------------
+test_latin1_binary(_) ->
+
+	Value = <<"Ahoy Vereld!">>,
+
+	worker_direct_insert(Value,latin1,Value),
+	worker_insert_via_statement(Value,latin1,Value),
+
+    ok.
+
+%% Worker Test Case: Latin 1 binary.
+%%--------------------------------------------------------------------
+test_latin1_liststring(_) ->
+
+	Value = "Ahoy Vereld!",
+	worker_direct_insert(Value,list_to_binary(Value)),
+	worker_insert_via_statement(Value,list_to_binary(Value)),
+    ok.
+
+
+%%--------------------------------------------------------------------
+%%
+%% Begin of actual tests.
+%%
+%%--------------------------------------------------------------------
+
+%% Test Case: Unicode binary.
+%%--------------------------------------------------------------------
+test_unicode_binary(_) ->
+
+	Value = <<"Ahöy Vereld!!!"/utf8>>,
+	worker_direct_insert(Value,utf8,Value),
+	worker_insert_via_statement(Value,utf8,Value),
+    ok.
+
+%% Test Case: Unicode binary.
+%%--------------------------------------------------------------------
+test_unicode_liststring(_) ->
+
+    Unicode = <<"Ahöy Vereld!!!!"/utf8>>,
+	Value   = unicode:characters_to_list(Unicode),
+
+    % N.B.
+    true = unicode:characters_to_list(<<"Ahöy Vereld!!!!"/utf8>>) 
+                    == binary_to_list(<<"Ahöy Vereld!!!!">>),
+
+	worker_direct_insert(Value,Unicode),
+	worker_insert_via_statement(Value,Unicode),
+	% direct insert /= via statement
+	% because the direct statement in this test suite is created
+	% from the binary directly, then executed, while the statement
+	% parameter is quoted, and for this must be 1) decoded into a 
+	% list of codepoints (a string) and 2) back. The list resulting
+	% from the decoding looks the same whether it was made from
+	% UTF-8 or Latin-1 binaries. The encoding back into a binary
+	% is then done using the set encoding for the connection,
+	% Latin-1 in this case. Therefore, what is sent to the database
+	% is Latin-1 when prepared statements are used with UTF-8 binaries.
+	% The automatic quoting cannot be done with full ('direct')
+	% query strings as this would quote their quotes. /hd mar-12
+	
+    ok.
+
+
+%% Test Case: Single Quote as binary.
+%%--------------------------------------------------------------------
+test_latin1_quote_as_binary(_) ->
+
+	Value = <<"'">>,
+	worker_direct_insert(Value,latin1,Value),
+	worker_insert_via_statement(Value,latin1,Value),
+    ok.
+
+%% Test Case: Single Quote as liststring.
+%%--------------------------------------------------------------------
+test_latin1_quote_as_liststring(_) ->
+
+	Value = "'",
+	worker_direct_insert(Value,list_to_binary(Value)),
+	worker_insert_via_statement(Value,list_to_binary(Value)),
+    ok.
+
+%% Test Case: Single Quote as unicode binary.
+%%--------------------------------------------------------------------
+test_unicode_quote_as_binary(_) ->
+
+	Value = <<"'"/utf8>>,
+	worker_direct_insert(Value,utf8,Value),
+	worker_insert_via_statement(Value,utf8,Value),
+    ok.
+
+%% Test Case: Single Quote as unicode liststring.
+%%--------------------------------------------------------------------
+test_unicode_quote_as_liststring(_) ->
+
+    Expect = <<"'"/utf8>>,
+	Value = unicode:characters_to_list(Expect),
+	worker_direct_insert(Value,Expect),
+	worker_insert_via_statement(Value,Expect),
+    ok.
+
+%% Test Case: Single Quote with text as binary.
+%%--------------------------------------------------------------------
+test_latin1_quote_and_text_as_binary(_) ->
+
+	Value = <<"Hank's">>,
+	worker_direct_insert(Value,latin1,Value),
+	worker_insert_via_statement(Value,latin1,Value),
+    ok.
+
+%% Test Case: Single Quote with text as liststring.
+%%--------------------------------------------------------------------
+test_latin1_quote_and_text_as_liststring(_) ->
+
+	Value = "Hank's",
+	worker_direct_insert(Value,list_to_binary(Value)),
+	worker_insert_via_statement(Value,list_to_binary(Value)),
+    ok.
+
+%% Test Case: Single Quote with text as unicode binary.
+%%--------------------------------------------------------------------
+test_unicode_quote_and_text_as_binary(_) ->
+
+	Value = <<"Hank's"/utf8>>,
+	worker_direct_insert(Value,utf8,Value),
+	worker_insert_via_statement(Value,utf8,Value),
+    ok.
+
+%% Test Case: Single Quote with text as unicode liststring.
+%%--------------------------------------------------------------------
+test_unicode_quote_and_text_as_liststring(_) ->
+
+    Expect = <<"Hank's"/utf8>>,
+	Value = unicode:characters_to_list(Expect),
+	worker_direct_insert(Value,Expect),
+	worker_insert_via_statement(Value,Expect),
+    ok.
+
+%% Test Case: Single Quote with trailing text as binary.
+%%--------------------------------------------------------------------
+test_latin1_quote_and_trailing_text_as_binary(_) ->
+
+	Value = <<"'gha!">>,
+	worker_direct_insert(Value,latin1,Value),
+	worker_insert_via_statement(Value,latin1,Value),
+    ok.
+
+%% Test Case: Single Quote with trailing text as liststring.
+%%--------------------------------------------------------------------
+test_latin1_quote_and_trailing_text_as_liststring(_) ->
+
+	Value = "'gha!",
+	worker_direct_insert(Value,list_to_binary(Value)),
+	worker_insert_via_statement(Value,list_to_binary(Value)),
+    ok.
+
+%% Test Case: Single Quote with trailing text as unicode binary.
+%%--------------------------------------------------------------------
+test_unicode_quote_and_trailing_text_as_binary(_) ->
+
+	Value = <<"'gha!"/utf8>>,
+	worker_direct_insert(Value,utf8,Value),
+	worker_insert_via_statement(Value,utf8,Value),
+    ok.
+
+%% Test Case: Single Quote with trailing text as unicode liststring.
+%%--------------------------------------------------------------------
+test_unicode_quote_and_trailing_text_as_liststring(_) ->
+
+	Value = unicode:characters_to_list(Expected = <<"'gha!"/utf8>>),
+	worker_direct_insert(Value,Expected),
+	worker_insert_via_statement(Value,Expected),
+    ok.
+
+%%--------------------------------------------------------------------
+%%
+%% More integrated tests.
+%%
+%%--------------------------------------------------------------------
+
+
+%% Worker: insert as binary.
+%%--------------------------------------------------------------------
+worker_insert_as_latin1_binary(V) ->
+
+	Value = list_to_binary(V),
+	io:format("~w~n", [list_to_binary(truncate(V))]),
+	worker_direct_insert(Value, latin1, list_to_binary(truncate(V))),
+
+    try 
+        unicode:characters_to_list(Value,utf8), % catch case trigger
+       	worker_insert_via_statement(Value, latin1, list_to_binary(truncate(V)))
+    catch
+        exit:{{invalid_utf8_binary,_,_}, {}} ->
+            try
+              	worker_insert_via_statement(Value, latin1, list_to_binary(truncate(V))),
+   	            exit(should_have_crashed)
+             catch
+                exit:{{invalid_utf8_binary,_,_}, {}} -> ok
+             end
+    end,
+    
+    ok.
+    
+    % The UTF-8 database truncates from the first invalid bitcode.
+    % Latin-1 bitcodes > 128 are invalid as UTF-8.
+    % Decoding a Latin-1 binary as if it was UTF-8 can lead to errors.
+    % These are tested for and caught here.
+
+%% Worker: insert as liststring.
+%%--------------------------------------------------------------------
+worker_insert_as_latin1_liststring(Value) ->
+
+	worker_direct_insert(Value,unicode:characters_to_binary(Value,utf8)),
+	worker_insert_via_statement(Value,unicode:characters_to_binary(Value,utf8)),
+    ok.
+
+%% Worker: insert as unicode binary.
+%%--------------------------------------------------------------------
+worker_insert_as_unicode_binary(V) ->
+
+    Value = unicode:characters_to_binary(V,latin1,utf8),
+	worker_direct_insert(Value,utf8,Value), 
+	worker_insert_via_statement(Value,utf8,Value),
+    ok.
+
+%% Worker: insert as unicode liststring.
+%%--------------------------------------------------------------------
+worker_insert_as_unicode_liststring(V) ->
+
+	Value = unicode:characters_to_list(V,latin1),
+	worker_direct_insert(Value,unicode:characters_to_binary(Value,utf8)),
+    worker_insert_via_statement(Value,unicode:characters_to_binary(Value,utf8)),
+    ok.
+
+
+%% Test Case: Single Quote with worker quartet single functions.
+%%--------------------------------------------------------------------
+test_worker_quartet_single_functions(_) ->
+
+	V = "'",
+	worker_insert_as_latin1_binary(V),
+	worker_insert_as_latin1_liststring(V),
+	worker_insert_as_unicode_binary(V),
+	worker_insert_as_unicode_liststring(V),
+	ok.
+
+%% Worker: Quartet
+%%--------------------------------------------------------------------
+worker_quartet(V) ->
+
+	worker_insert_as_latin1_binary(V),
+	worker_insert_as_latin1_liststring(V),
+	worker_insert_as_unicode_binary(V),
+	worker_insert_as_unicode_liststring(V),
+	ok.
+
+%% Test Case: Single Quote with worker quartet function.
+%%--------------------------------------------------------------------
+test_worker_quartet(_) ->
+
+	worker_quartet("'"),
+	ok.
+
+%% Test Case: Odd character combinations to be escaped.
+%%--------------------------------------------------------------------
+test_escaping(_) ->
+
+	worker_quartet("'"),
+	worker_quartet("''"),
+	worker_quartet("'b!"),
+	worker_quartet("s'"),
+	worker_quartet("'t'"),
+	worker_quartet("t't"),
+	worker_quartet("'''"),
+	worker_quartet("s'''"),
+	worker_quartet("''ss"),
+	worker_quartet("\\"),
+	worker_quartet("\""),
+	worker_quartet("\"\""),
+	worker_quartet("\"'\""),
+	worker_quartet("\\'"),
+	worker_quartet("\\\""),
+	worker_quartet("\\\"h\""),
+	ok.
+
+%% Test Case: Odd character combinations to be escaped with non latin1s.
+%%--------------------------------------------------------------------
+test_escaping_with_non_latin1(_) ->
+
+	worker_quartet("'öüx"),
+	worker_quartet("''ö"),
+	worker_quartet("'b!ö"),
+	worker_quartet("s'ö"),
+	worker_quartet("'t'ö"),
+	worker_quartet("t'tö"),
+	worker_quartet("'''ö"),
+	worker_quartet("s'''ö"),
+	worker_quartet("''ssö"),
+	worker_quartet("\\ö"),
+	worker_quartet("\"ö"),
+	worker_quartet("\"\"ö"),
+	worker_quartet("\"'\"ö"),
+	worker_quartet("\\'ö"),
+	worker_quartet("\\\"ö"),
+	worker_quartet("\\\"h\"ö"),
+	worker_quartet("ö'"),
+	worker_quartet("ö''"),
+	worker_quartet("ö'b!"),
+	worker_quartet("ös'"),
+	worker_quartet("ö't'"),
+	worker_quartet("öt't"),
+	worker_quartet("ö'''"),
+	worker_quartet("ös'''"),
+	worker_quartet("ö''ss"),
+	worker_quartet("ö\\"),
+	worker_quartet("ö\""),
+	worker_quartet("ö\"\""),
+	worker_quartet("ö\"'\""),
+	worker_quartet("ö\\'"),
+	worker_quartet("ö\\\""),
+	worker_quartet("ö\\\"h\""),
+
+	ok.
+
+%% Test Case: Odd character combinations to be escaped with non latin1s.
+%%--------------------------------------------------------------------
+test_escaping_with_non_latin1_leading_umlaut(_) ->
+
+	worker_quartet("ü'öüx"),
+	worker_quartet("ü'ö"),
+	worker_quartet("ü''ö"),
+	worker_quartet("ü'b!ö"),
+	worker_quartet("üs'ö"),
+	worker_quartet("ü't'ö"),
+	worker_quartet("üt'tö"),
+	worker_quartet("ü'''ö"),
+	worker_quartet("üs'''ö"),
+	worker_quartet("ü''ssö"),
+	worker_quartet("ü\\ö"),
+	worker_quartet("ü\"ö"),
+	worker_quartet("ü\"\"ö"),
+	worker_quartet("ü\"'\"ö"),
+	worker_quartet("ü\\'ö"),
+	worker_quartet("ü\\\"ö"),
+	worker_quartet("ü\\\"h\"ö"),
+	worker_quartet("üö'"),
+	worker_quartet("üö''"),
+	worker_quartet("üö'b!"),
+	worker_quartet("üös'"),
+	worker_quartet("üö't'"),
+	worker_quartet("üöt't"),
+	worker_quartet("üö'''"),
+	worker_quartet("üös'''"),
+	worker_quartet("üö''ss"),
+	worker_quartet("üö\\"),
+	worker_quartet("üö\""),
+	worker_quartet("üö\"\""),
+	worker_quartet("üö\"'\""),
+	worker_quartet("üö\\'"),
+	worker_quartet("üö\\\""),
+	worker_quartet("üö\\\"h\""),
+
+	ok.
+
+
+%% make ? of chars > 127.
+%% That is what MySQL does to invalid UTF-8 characters.
+castrate(Bin) when is_binary(Bin) ->
+	list_to_binary(lists:reverse(castrate(binary_to_list(Bin), [])));
+	% note: this is a bytewise inspection that works for unicode, too.
+
+castrate(L) when is_list(L) ->
+	lists:reverse(castrate(L, [])).
+	% note: this is a bytewise inspection that works for unicode, too.
+
+castrate([], Acc) ->
+	Acc;
+castrate([C | Rest], Acc) when C < 128 ->
+	castrate(Rest, [C | Acc]);
+castrate([_ | Rest], Acc) ->
+	castrate(Rest, [$? | Acc]).
+
+%% truncate at chars > 127.
+%% That is what MySQL does to invalid UTF-8 characters.
+truncate(Bin) when is_binary(Bin) ->
+	list_to_binary(lists:reverse(truncate(binary_to_list(Bin), [])));
+	% note: this is a bytewise inspection that works for unicode, too.
+
+truncate(L) when is_list(L) ->
+	lists:reverse(truncate(L, [])).
+
+truncate([], Acc) ->
+	Acc;
+truncate([C | Rest], Acc) when C < 128 ->
+	truncate(Rest, [C | Acc]);
+truncate(_, Acc) ->
+	Acc.
+
+encode(Bin) when is_binary(Bin) ->
+    unicode:characters_to_binary(binary_to_list(Bin));
+encode(Bin) when is_list(Bin) ->
+    unicode:characters_to_binary(Bin).


### PR DESCRIPTION
utf8 only supports 3 bytes of character encoding. To support the full 4 bytes, you need to use utf8mb4.
