### PR TITLE
Allow connect without changing database

### DIFF
--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -36,6 +36,7 @@
 -include("emysql.hrl").
 
 set_database(_, undefined) -> ok;
+set_database(_, Empty) when Empty == ""; Empty == <<>> -> ok;
 set_database(Connection, Database) ->
 	Packet = <<?COM_QUERY, "use ", (iolist_to_binary(Database))/binary>>,  % todo: utf8?
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).
@@ -163,6 +164,7 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
 			},
 			%-% io:format("~p open connection: ... set db ...~n", [self()]),
 			case emysql_conn:set_database(Connection, Database) of
+				ok -> ok;
 				OK1 when is_record(OK1, ok_packet) ->
 					 %-% io:format("~p open connection: ... db set ok~n", [self()]),
 					ok;

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -38,7 +38,7 @@
 set_database(_, undefined) -> ok;
 set_database(_, Empty) when Empty == ""; Empty == <<>> -> ok;
 set_database(Connection, Database) ->
-	Packet = <<?COM_QUERY, "use ", (iolist_to_binary(Database))/binary>>,  % todo: utf8?
+	Packet = <<?COM_QUERY, "use `", (iolist_to_binary(Database))/binary, "`">>,  % todo: utf8?
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).
 
 set_encoding(Connection, Encoding) ->


### PR DESCRIPTION
There's no reason to require changing to a database on connect.

set_database already supported undefined, so I extended to support empty string.

Prior to this change, specifying undefined as the database caused a case error.

Now you can specify either undefined or an empty string (list or binary) to avoid
using the database on connect.

This is admittedly an edge case, but there's a good practical reason: the Sphinx
search daemon exposes a MySQL socket interface, which works very well with
Erlang MySQL drivers. It does not support changing databases.

Also includes support for database names containing dashes.
