### PR TITLE
Per-pool timezone support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,11 @@ encoding-test: all
 	(cd test; ct_run -suite latin_SUITE utf8_SUITE utf8_to_latindb_SUITE latin_to_utf8db_SUITE -pa ../ebin $(CRYPTO_PATH))
 
 test: all
-	(cd test; ct_run -suite environment_SUITE basics_SUITE conn_mgr_SUITE -pa ../ebin $(CRYPTO_PATH))
+	(cd test; \
+		ct_run -suite environment_SUITE basics_SUITE conn_mgr_SUITE \
+		-pa ../ebin $(CRYPTO_PATH) \
+		-include .. \
+	)
 
 test20: all
 	(cd test; ct_run -suite pool_SUITE -pa ../ebin $(CRYPTO_PATH))

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The Emysql driver is an Erlang gen-server, and, application.
     %%		Port = integer()
     %%    Database = undefined | string()
     %%		Options = [Option]
-    %%		Option = {encoding, string()} | {time_zone, string()}
+    %%		Option = {encoding, string()} | {time_zone, string()} | {sql_mode, string()}
     %%		Result = {reply, {error, pool_already_exists}, state()} | {reply, ok, state()}
 
     emysql:add_pool(mypoolname, 1, "username", "mypassword", "localhost", 3306,

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ This is a hello world program. Follow the three steps below to try it out.
 		application:start(emysql),
 	
 		emysql:add_pool(hello_pool, 1,
-			"hello_username", "hello_password", "localhost", 3306,
-			[{database, "hello_database"}, {encoding, utf8}]),
+			"hello_username", "hello_password", "localhost", 3306, "hello_database",
+			[{encoding, utf8}]),
 	
 		emysql:execute(hello_pool,
 			<<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
@@ -130,8 +130,8 @@ For the exact spec, see below, [Usage][]. Regarding the 'pool', also see below.
 
 Emysql uses a sophisticated connection pooling mechanism.
 
-	emysql:add_pool(my_pool, 1, "myuser", "mypass", "myhost", 3306,
-      [{database, "mydatabase"}, {encoding, utf8}]).
+	emysql:add_pool(my_pool, 1, "myuser", "mypass", "myhost", 3306, "mydatabase",
+      [{encoding, utf8}]).
 
 ### Running Hello World
 
@@ -212,19 +212,20 @@ The Emysql driver is an Erlang gen-server, and, application.
 
 #### Adding a Pool                                  <a name="Adding_a_Pool"></a>
 
-    %% emysql:add_pool(PoolId, Size, User, Password, Host, Port, Options) -> Result
+    %% emysql:add_pool(PoolId, Size, User, Password, Host, Port, Database, Options) -> Result
     %%		PoolId = atom()
     %%		Size = integer()
     %%		User = string()
     %%		Password = string()
     %%		Host = string()
     %%		Port = integer()
+    %%    Database = undefined | string()
     %%		Options = [Option]
-    %%		Option = {database, string()} | {encoding, string()} | {time_zone, string()}
+    %%		Option = {encoding, string()} | {time_zone, string()}
     %%		Result = {reply, {error, pool_already_exists}, state()} | {reply, ok, state()}
 
     emysql:add_pool(mypoolname, 1, "username", "mypassword", "localhost", 3306,
-        [{database, "mydatabase"}, {encoding, utf8}]).
+               "mydatabase", [{encoding, utf8}]).
 
 `Options` proplist is optional. However, if encoding is not specified, default is `utf8`
 
@@ -232,6 +233,7 @@ Older version of `emysql:add_pool/8` is kept for backwards compatibility:
 
     emysql:add_pool(PoolId, Size, User, Password, Host, Port, Database, Encoding)
 
+      %% Encoding = atom()
 
 #### More Record Types
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This is a hello world program. Follow the three steps below to try it out.
 	
 		emysql:add_pool(hello_pool, 1,
 			"hello_username", "hello_password", "localhost", 3306,
-			"hello_database", utf8),
+			[{database, "hello_database"}, {encoding, utf8}]),
 	
 		emysql:execute(hello_pool,
 			<<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
@@ -130,7 +130,8 @@ For the exact spec, see below, [Usage][]. Regarding the 'pool', also see below.
 
 Emysql uses a sophisticated connection pooling mechanism.
 
-	emysql:add_pool(my_pool, 1, "myuser", "mypass", "myhost", 3306, "mydatabase", utf8).
+	emysql:add_pool(my_pool, 1, "myuser", "mypass", "myhost", 3306,
+      [{database, "mydatabase"}, {encoding, utf8}]).
 
 ### Running Hello World
 
@@ -211,18 +212,26 @@ The Emysql driver is an Erlang gen-server, and, application.
 
 #### Adding a Pool                                  <a name="Adding_a_Pool"></a>
 
-	% emysql:add_pool(PoolName, PoolSize, Username, Password, Host, Port, Database, Encoding) ->
-	%	 ok | {error, pool_already_exists}  
-	% PoolName = atom()  
-	% PoolSize = integer()  
-	% Username = string()  
-	% Password = string()  
-	% Host = string()  
-	% Port = integer()  
-	% Database = string()  
-	% Encoding = atom()  
-	
-	emysql:add_pool(mypoolname, 1, "username", "mypassword", "localhost", 3306, "mydatabase", utf8).
+    %% emysql:add_pool(PoolId, Size, User, Password, Host, Port, Options) -> Result
+    %%		PoolId = atom()
+    %%		Size = integer()
+    %%		User = string()
+    %%		Password = string()
+    %%		Host = string()
+    %%		Port = integer()
+    %%		Options = [Option]
+    %%		Option = {database, string()} | {encoding, string()}
+    %%		Result = {reply, {error, pool_already_exists}, state()} | {reply, ok, state()}
+
+    emysql:add_pool(mypoolname, 1, "username", "mypassword", "localhost", 3306,
+        [{database, "mydatabase"}, {encoding, utf8}]).
+
+`Options` proplist is optional. However, if encoding is not specified, default is `utf8`
+
+Older version of `emysql:add_pool/8` is kept for backwards compatibility:
+
+    emysql:add_pool(PoolId, Size, User, Password, Host, Port, Database, Encoding)
+
 
 #### More Record Types
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The Emysql driver is an Erlang gen-server, and, application.
     %%		Host = string()
     %%		Port = integer()
     %%		Options = [Option]
-    %%		Option = {database, string()} | {encoding, string()}
+    %%		Option = {database, string()} | {encoding, string()} | {time_zone, string()}
     %%		Result = {reply, {error, pool_already_exists}, state()} | {reply, ok, state()}
 
     emysql:add_pool(mypoolname, 1, "username", "mypassword", "localhost", 3306,

--- a/include/emysql.hrl
+++ b/include/emysql.hrl
@@ -26,7 +26,7 @@
 %% OTHER DEALINGS IN THE SOFTWARE.
 
 
--record(pool, {pool_id, size, user, password, host, port, database, encoding, available=queue:new(), locked=gb_trees:empty(), waiting=queue:new()}).
+-record(pool, {pool_id, size, user, password, host, port, options, available=queue:new(), locked=gb_trees:empty(), waiting=queue:new()}).
 -record(emysql_connection, {id, pool_id, encoding, socket, version, thread_id, caps, language, prepared=gb_trees:empty(), locked_at, alive=true}).
 -record(greeting, {protocol_version, server_version, thread_id, salt1, salt2, caps, caps_high, language, status, seq_num, plugin}).
 -record(field, {seq_num, catalog, db, table, org_table, name, org_name, type, default, charset_nr, length, flags, decimals}).
@@ -35,6 +35,8 @@
 -record(error_packet, {seq_num, code, status, msg}).
 -record(eof_packet, {seq_num, status, warning_count}). % extended to mySQL 4.1+ format
 -record(result_packet, {seq_num, field_list, rows, extra}).
+
+-define(DEFAULT_ENCODING, utf8).
 
 -define(TIMEOUT, 8000).
 -define(LOCK_TIMEOUT, 5000).

--- a/include/emysql.hrl
+++ b/include/emysql.hrl
@@ -26,7 +26,7 @@
 %% OTHER DEALINGS IN THE SOFTWARE.
 
 
--record(pool, {pool_id, size, user, password, host, port, options, available=queue:new(), locked=gb_trees:empty(), waiting=queue:new()}).
+-record(pool, {pool_id, size, user, password, host, port, database, options, available=queue:new(), locked=gb_trees:empty(), waiting=queue:new()}).
 -record(emysql_connection, {id, pool_id, encoding, socket, version, thread_id, caps, language, prepared=gb_trees:empty(), locked_at, alive=true}).
 -record(greeting, {protocol_version, server_version, thread_id, salt1, salt2, caps, caps_high, language, status, seq_num, plugin}).
 -record(field, {seq_num, catalog, db, table, org_table, name, org_name, type, default, charset_nr, length, flags, decimals}).

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -197,7 +197,7 @@ default_timeout() ->
 %%		Port = integer()
 %%		Database = undefined | string()
 %%		Options = [Option]
-%%		Option = {encoding, string()} | {time_zone, string()}
+%%		Option = {encoding, string()} | {time_zone, string()} | {sql_mode, string()}
 %%		Result = {reply, {error, pool_already_exists}, state()} | {reply, ok, state() }
 %%
 %% @doc Synchronous call to the connection manager to add a pool.

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -197,7 +197,7 @@ default_timeout() ->
 %%		Host = string()
 %%		Port = integer()
 %%		Options = [Option]
-%%		Option = {database, string()} | {encoding, string()}
+%%		Option = {database, string()} | {encoding, string()} | {time_zone, string()}
 %%		Result = {reply, {error, pool_already_exists}, state()} | {reply, ok, state() }
 %%
 %% @doc Synchronous call to the connection manager to add a pool.

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -46,6 +46,11 @@ set_encoding(Connection, Encoding) ->
 	Packet = <<?COM_QUERY, "set names '", (erlang:atom_to_binary(Encoding, utf8))/binary, "'">>,
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).
 
+set_sql_mode(_, undefined) -> ok;
+set_sql_mode(Connection, SqlMode) ->
+	Packet = <<?COM_QUERY, "set sql_mode='", (iolist_to_binary(SqlMode))/binary, "'">>,
+	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).
+
 set_time_zone(_, undefined) -> ok;
 set_time_zone(Connection, Timezone) ->
 	Packet = <<?COM_QUERY, "set time_zone='", (iolist_to_binary(Timezone))/binary, "'">>,
@@ -208,6 +213,13 @@ set_options(Connection, Options) ->
             ok;
         Err3 when is_record(Err3, error_packet) ->
             exit({failed_to_set_time_zone, Err3#error_packet.msg})
+	end,
+
+    case set_sql_mode(Connection, proplists:get_value(sql_mode, Options)) of
+        OK4 when OK4 =:= ok orelse is_record(OK4, ok_packet) ->
+            ok;
+        Err4 when is_record(Err4, error_packet) ->
+            exit({failed_to_set_sql_mode, Err4#error_packet.msg})
 	end.
 
 

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -35,6 +35,8 @@
 
 -include("emysql.hrl").
 
+set_database(_, "") -> ok;
+set_database(_, <<>>) -> ok;
 set_database(_, undefined) -> ok;
 set_database(Connection, Database) ->
 	Packet = <<?COM_QUERY, "use ", (iolist_to_binary(Database))/binary>>,  % todo: utf8?
@@ -142,7 +144,8 @@ open_connections(Pool) ->
 			Pool
 	end.
 
-open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=Password, options=Options}) ->
+open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User,
+    password=Password, database=Database, options=Options}) ->
 	Encoding = proplists:get_value(encoding, Options),
 	 %-% io:format("~p open connection for pool ~p host ~p port ~p user ~p base ~p~n", [self(), PoolId, Host, Port, User, Database]),
 	 %-% io:format("~p open connection: ... connect ... ~n", [self()]),
@@ -168,6 +171,14 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
 				language = Greeting#greeting.language
 			},
 			%-% io:format("~p open connection: ... set db ...~n", [self()]),
+			case set_database(Connection, Database) of
+			  OK1 when OK1 =:= ok orelse is_record(OK1, ok_packet) ->
+				%-% io:format("~p open connection: ... db set ok~n", [self()]),
+				ok;
+			  Err1 when is_record(Err1, error_packet) ->
+				%-% io:format("~p open connection: ... db set error~n", [self()]),
+				exit({failed_to_set_database, Err1#error_packet.msg})
+			end,
 			set_options(Connection, Options),
 			 %-% io:format("~p open connection: ... ok, return connection~n", [self()]),
 			Connection;
@@ -184,18 +195,8 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
 %%
 %% In theory encoding should be optional, but it must be defined for historical reasons.
 set_options(Connection, Options) ->
-    case set_database(Connection, proplists:get_value(database, Options)) of
-        OK1 when OK1 =:= ok orelse is_record(OK1, ok_packet) ->
-            %-% io:format("~p open connection: ... db set ok~n", [self()]),
-            ok;
-        Err1 when is_record(Err1, error_packet) ->
-            %-% io:format("~p open connection: ... db set error~n", [self()]),
-            exit({failed_to_set_database, Err1#error_packet.msg})
-	end,
-
 	%-% io:format("~p open connection: ... set encoding ...: ~p~n", [self(), Encoding]),
-	Encoding = proplists:get_value(encoding, Options),
-	case set_encoding(Connection, Encoding) of
+	case set_encoding(Connection, proplists:get_value(encoding, Options)) of
 		OK2 when is_record(OK2, ok_packet) ->
 			ok;
 		Err2 when is_record(Err2, error_packet) ->

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -336,7 +336,9 @@ initialize_pools() ->
 			port = proplists:get_value(port, Props),
 			options = [
 				{database, proplists:get_value(database, Props)},
-				{time_zone, proplists:get_value(time_zone, Props)}
+				{time_zone, proplists:get_value(time_zone, Props)},
+				{encoding,
+					proplists:get_value(encoding, Props, ?DEFAULT_ENCODING)}
 			]
 		} || {PoolId, Props} <- emysql_app:pools()
 	].

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -334,8 +334,10 @@ initialize_pools() ->
 			password = proplists:get_value(password, Props),
 			host = proplists:get_value(host, Props),
 			port = proplists:get_value(port, Props),
-			database = proplists:get_value(database, Props),
-			encoding = proplists:get_value(encoding, Props)
+			options = [
+				{database, proplists:get_value(database, Props)},
+				{time_zone, proplists:get_value(time_zone, Props)}
+			]
 		} || {PoolId, Props} <- emysql_app:pools()
 	].
 

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -334,8 +334,8 @@ initialize_pools() ->
 			password = proplists:get_value(password, Props),
 			host = proplists:get_value(host, Props),
 			port = proplists:get_value(port, Props),
+            database = proplists:get_value(database, Props),
 			options = [
-				{database, proplists:get_value(database, Props)},
 				{time_zone, proplists:get_value(time_zone, Props)},
 				{encoding,
 					proplists:get_value(encoding, Props, ?DEFAULT_ENCODING)}

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -275,7 +275,7 @@ quote(String, _) when is_list(String) ->
 	quote(String);
 	
 quote(Any, Pool) when is_record(Any,pool) ->
-	quote(Any, Pool#pool.encoding);
+	quote(Any, proplists:get_value(encoding, Pool#pool.options));
 	
 quote(Bin, latin1) when is_binary(Bin) ->
 	list_to_binary(quote(binary_to_list(Bin)));

--- a/test/environment_SUITE.erl
+++ b/test/environment_SUITE.erl
@@ -38,10 +38,13 @@
         insert_a_record/1,
         select_a_record/1,
 
-        add_pool_default/1,
+        add_pool_undefined/1,
+        add_pool_empty_bin/1,
+        add_pool_empty_list/1,
         add_pool_database/1,
         add_pool_utf8/1,
         add_pool_latin1/1,
+        add_pool_latin1_compatible/1,
         add_pool_time_zone/1
     ]).
 
@@ -57,10 +60,13 @@ all() ->
         insert_a_record,
         select_a_record,
 
-        add_pool_default,
+        add_pool_undefined,
+        add_pool_empty_bin,
+        add_pool_empty_list,
         add_pool_database,
         add_pool_utf8,
         add_pool_latin1,
+        add_pool_latin1_compatible,
         add_pool_time_zone
     ].
 
@@ -79,10 +85,13 @@ end_per_testcase(T, _) when
         T == connecting_to_db_and_creating_a_pool_transition orelse
         T == insert_a_record orelse
         T == select_a_record orelse
-        T == add_pool_default orelse
+        T == add_pool_undefined orelse
+        T == add_pool_empty_bin orelse
+        T == add_pool_empty_list orelse
         T == add_pool_database orelse
         T == add_pool_utf8 orelse
         T == add_pool_latin1 orelse
+        T == add_pool_latin1_compatible orelse
         T == add_pool_time_zone ->
 	emysql:remove_pool(?POOL);
 
@@ -129,34 +138,52 @@ select_a_record(_) ->
 
 % Test Case: Test if we can connect to the test db and create a connection pool.
 %%--------------------------------------------------------------------
-add_pool_default(_) ->
+add_pool_undefined(_) ->
     emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
-        3306),
+        3306, undefined),
     #result_packet{rows=[[undefined]]} =
     emysql:execute(?POOL, <<"SELECT DATABASE();">>),
     #result_packet{rows=[[<<"utf8">>]]} =
     emysql:execute(?POOL, <<"SELECT @@character_set_connection;">>).
 
+add_pool_empty_bin(_) ->
+    emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
+        3306, <<"">>),
+    #result_packet{rows=[[undefined]]} =
+    emysql:execute(?POOL, <<"SELECT DATABASE();">>).
+
+add_pool_empty_list(_) ->
+    emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
+        3306, ""),
+    #result_packet{rows=[[undefined]]} =
+    emysql:execute(?POOL, <<"SELECT DATABASE();">>).
+
 add_pool_database(_) ->
     emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
-        3306, [{database, "hello_database"}]),
+        3306, "hello_database"),
     #result_packet{rows=[[<<"hello_database">>]]} =
     emysql:execute(?POOL, <<"SELECT DATABASE();">>).
 
 add_pool_utf8(_) ->
     emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
-        3306, [{encoding, utf8}]),
+        3306, undefined, [{encoding, utf8}]),
     #result_packet{rows=[[<<"utf8">>]]} =
     emysql:execute(?POOL, <<"SELECT @@character_set_connection;">>).
 
 add_pool_latin1(_) ->
     emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
-        3306, [{encoding, latin1}]),
+        3306, undefined, [{encoding, latin1}]),
+    #result_packet{rows=[[<<"latin1">>]]} =
+    emysql:execute(?POOL, <<"SELECT @@character_set_connection;">>).
+
+add_pool_latin1_compatible(_) ->
+    emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
+        3306, undefined, latin1),
     #result_packet{rows=[[<<"latin1">>]]} =
     emysql:execute(?POOL, <<"SELECT @@character_set_connection;">>).
 
 add_pool_time_zone(_) ->
     emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
-        3306, [{time_zone, "+00:00"}]),
+        3306, undefined, [{time_zone, "+00:00"}]),
     #result_packet{rows=[[<<"+00:00">>]]} =
     emysql:execute(?POOL, <<"SELECT @@time_zone;">>).

--- a/test/environment_SUITE.erl
+++ b/test/environment_SUITE.erl
@@ -41,7 +41,8 @@
         add_pool_default/1,
         add_pool_database/1,
         add_pool_utf8/1,
-        add_pool_latin1/1
+        add_pool_latin1/1,
+        add_pool_time_zone/1
     ]).
 
 % List of test cases.
@@ -59,7 +60,8 @@ all() ->
         add_pool_default,
         add_pool_database,
         add_pool_utf8,
-        add_pool_latin1
+        add_pool_latin1,
+        add_pool_time_zone
     ].
 
 init_per_testcase(T, Config) when
@@ -80,7 +82,8 @@ end_per_testcase(T, _) when
         T == add_pool_default orelse
         T == add_pool_database orelse
         T == add_pool_utf8 orelse
-        T == add_pool_latin1 ->
+        T == add_pool_latin1 orelse
+        T == add_pool_time_zone ->
 	emysql:remove_pool(?POOL);
 
 end_per_testcase(_, _) ->
@@ -152,3 +155,8 @@ add_pool_latin1(_) ->
     #result_packet{rows=[[<<"latin1">>]]} =
     emysql:execute(?POOL, <<"SELECT @@character_set_connection;">>).
 
+add_pool_time_zone(_) ->
+    emysql:add_pool(?POOL, 10, "hello_username", "hello_password", "localhost",
+        3306, [{time_zone, "+00:00"}]),
+    #result_packet{rows=[[<<"+00:00">>]]} =
+    emysql:execute(?POOL, <<"SELECT @@time_zone;">>).


### PR DESCRIPTION
This pull request consists of 2 commits:
1. Logically separate emysql:add_pool API to two stages: required and optional
2. Add per-pool time_zone support

First commit also makes much easier to add other per-pool parameters.

This pull request is backwards compatible.

Supersedes #42.
