### PR TITLE
use default timeout for recv

### DIFF
--- a/include/emysql.hrl
+++ b/include/emysql.hrl
@@ -37,6 +37,7 @@
 -record(result_packet, {seq_num, field_list, rows, extra}).
 
 -define(TIMEOUT, 8000).
+-define(RECV_TIMEOUT_OFFSET, 500).
 -define(LOCK_TIMEOUT, 5000).
 -define(MAXPACKETBYTES, 50000000).
 -define(LONG_PASSWORD, 1).

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -234,12 +234,28 @@ close_connection(Conn) ->
 %%--------------------------------------------------------------------
 set_params(_, _, [], Result) -> Result;
 set_params(_, _, _, Error) when is_record(Error, error_packet) -> Error;
-set_params(Connection, Num, [Val|Tail], _) ->
-	NumBin = emysql_util:encode(Num, binary, Connection#emysql_connection.encoding), 
-	ValBin = emysql_util:encode(Val, binary, Connection#emysql_connection.encoding), % can trigger conversion
-	Packet = <<?COM_QUERY, "SET @", NumBin/binary, "=", ValBin/binary>>,
-	Result = emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0),
-	set_params(Connection, Num+1, Tail, Result).
+set_params(Connection, Num, Values, _) ->
+	Packet = set_params_packet(Num, Values, Connection#emysql_connection.encoding),
+	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).
+
+set_params_packet(NumStart, Values, Encoding) ->
+	BinValues = [emysql_util:encode(Val, binary, Encoding) || Val <- Values],
+	BinNums = [emysql_util:encode(Num, binary, Encoding) || Num <- lists:seq(NumStart, NumStart + length(Values) - 1)],
+	BinPairs = lists:zip(BinNums, BinValues),
+	Parts = [<<"@", NumBin/binary, "=", ValBin/binary>> || {NumBin, ValBin} <- BinPairs], 
+	Sets = list_to_binary(join(Parts, <<",">>)),
+	<<?COM_QUERY, "SET ", Sets/binary>>.
+
+%% @doc Join elements of list with Sep
+%%
+%% 1> join([1,2,3], 0).
+%% [1,0,2,0,3]
+
+join([], _Sep) -> [];
+join(L, Sep) -> join(L, Sep, []).
+
+join([H], _Sep, Acc)  -> lists:reverse([H|Acc]);
+join([H|T], Sep, Acc) -> join(T, Sep, [Sep, H|Acc]).
 
 prepare_statement(Connection, StmtName) ->
 	case emysql_statements:fetch(StmtName) of

--- a/src/emysql_tcp.erl
+++ b/src/emysql_tcp.erl
@@ -150,7 +150,7 @@ response(Sock, #packet{seq_num = SeqNum, data = Data}=_Packet) ->
 recv_packet_header(Sock) ->
 	%-% io:format("~p recv_packet_header~n", [self()]),
 	%-% io:format("~p recv_packet_header: recv~n", [self()]),
-	case gen_tcp:recv(Sock, 4, ?TIMEOUT) of
+    case gen_tcp:recv(Sock, 4, emysql_app:default_timeout()) of
 		{ok, <<PacketLength:24/little-integer, SeqNum:8/integer>>} ->
 			%-% io:format("~p recv_packet_header: ok~n", [self()]),
 			{PacketLength, SeqNum};

--- a/src/emysql_tcp.erl
+++ b/src/emysql_tcp.erl
@@ -150,7 +150,7 @@ response(Sock, #packet{seq_num = SeqNum, data = Data}=_Packet) ->
 recv_packet_header(Sock) ->
 	%-% io:format("~p recv_packet_header~n", [self()]),
 	%-% io:format("~p recv_packet_header: recv~n", [self()]),
-    case gen_tcp:recv(Sock, 4, emysql_app:default_timeout()) of
+    case gen_tcp:recv(Sock, 4, emysql_app:default_timeout() - ?RECV_TIMEOUT_OFFSET) of
 		{ok, <<PacketLength:24/little-integer, SeqNum:8/integer>>} ->
 			%-% io:format("~p recv_packet_header: ok~n", [self()]),
 			{PacketLength, SeqNum};

--- a/src/emysql_tcp.erl
+++ b/src/emysql_tcp.erl
@@ -184,7 +184,7 @@ recv_packet_body(Sock, PacketLength, Acc) ->
         PacketLength > ?PACKETSIZE->
             case gen_tcp:recv(Sock, ?PACKETSIZE, ?TIMEOUT) of
                 {ok, Bin} ->
-                    recv_packet_body(Sock, PacketLength, [Bin|Acc]);
+                    recv_packet_body(Sock, PacketLength - ?PACKETSIZE, [Bin|Acc]);
                 {error, Reason1} ->
                     exit({failed_to_recv_packet_body, Reason1})
             end;

--- a/src/emysql_tcp.erl
+++ b/src/emysql_tcp.erl
@@ -31,7 +31,6 @@
 -include("emysql.hrl").
 
 -define(PACKETSIZE, 1460).
--define(ETS_SELECT(TableID), ets:select(TableID,[{{'_','$2'},[],['$2']}])).
 
 send_and_recv_packet(Sock, Packet, SeqNum) ->
 	%-% io:format("~nsend_and_receive_packet: SEND SeqNum: ~p, Binary: ~p~n", [SeqNum, <<(size(Packet)):24/little, SeqNum:8, Packet/binary>>]),
@@ -178,47 +177,37 @@ recv_packet_header(Sock) ->
 %	end.
 
 recv_packet_body(Sock, PacketLength) ->
-	Tid = ets:new(emysql_buffer, [ordered_set, private]),
-	Bin = recv_packet_body(Sock, PacketLength, Tid, 0),
-	ets:delete(Tid),
-	Bin.
+    recv_packet_body(Sock, PacketLength, []).
 
-recv_packet_body(Sock, PacketLength, Tid, Key) ->
-	if
-		PacketLength > ?PACKETSIZE ->
-			case gen_tcp:recv(Sock, ?PACKETSIZE, ?TIMEOUT) of
-				{ok, Bin} ->
-					ets:insert(Tid, {Key, Bin}),
-					recv_packet_body(Sock, PacketLength - ?PACKETSIZE, Tid, Key+1);
-				{error, Reason1} ->
-					exit({failed_to_recv_packet_body, Reason1})
-			end;
-		true ->
-			case gen_tcp:recv(Sock, PacketLength, ?TIMEOUT) of
-				{ok, Bin} ->
-					if
-						Key == 0 -> Bin;
-						true -> iolist_to_binary(?ETS_SELECT(Tid) ++ Bin)
-					end;
-				{error, Reason1} ->
-					exit({failed_to_recv_packet_body, Reason1})
-			end
-	end.
+recv_packet_body(Sock, PacketLength, Acc) ->
+    if
+        PacketLength > ?PACKETSIZE->
+            case gen_tcp:recv(Sock, ?PACKETSIZE, ?TIMEOUT) of
+                {ok, Bin} ->
+                    recv_packet_body(Sock, PacketLength, [Bin|Acc]);
+                {error, Reason1} ->
+                    exit({failed_to_recv_packet_body, Reason1})
+            end;
+        true ->
+            case gen_tcp:recv(Sock, PacketLength, ?TIMEOUT) of
+                {ok, Bin} ->
+                    iolist_to_binary(lists:reverse([Bin|Acc]));
+                {error, Reason1} ->
+                    exit({failed_to_recv_packet_body, Reason1})
+            end
+    end.
 
 recv_field_list(Sock, SeqNum) ->
-	Tid = ets:new(emysql_field_list, [ordered_set, private]),
-	Res = recv_field_list(Sock, SeqNum, Tid, 0),
-	ets:delete(Tid),
-	Res.
+    recv_field_list(Sock, SeqNum, []).
 
-recv_field_list(Sock, _SeqNum, Tid, Key) ->
+recv_field_list(Sock, _SeqNum, Acc) ->
 	case recv_packet(Sock) of
 		#packet{seq_num = SeqNum1, data = <<?RESP_EOF, _WarningCount:16/little, _ServerStatus:16/little>>} -> % (*)!
 			%-% io:format("- eof: ~p~n", [emysql_conn:hstate(_ServerStatus)]),
-			{SeqNum1, ?ETS_SELECT(Tid)};
+                        {SeqNum1, lists:reverse(Acc)};
 		#packet{seq_num = SeqNum1, data = <<?RESP_EOF, _/binary>>} ->
 			%-% io:format("- eof~n", []),
-			{SeqNum1, ?ETS_SELECT(Tid)};
+                        {SeqNum1, lists:reverse(Acc)};
 		#packet{seq_num = SeqNum1, data = Data} ->
 			{Catalog, Rest2} = emysql_util:length_coded_string(Data),
 			{Db, Rest3} = emysql_util:length_coded_string(Rest2),
@@ -244,30 +233,25 @@ recv_field_list(Sock, _SeqNum, Tid, Key) ->
 				flags = Flags,
 				decimals = Decimals
 			},
-			ets:insert(Tid, {Key, Field}),
-			recv_field_list(Sock, SeqNum1, Tid, Key+1)
+			recv_field_list(Sock, SeqNum1, [Field|Acc])
 	end.
 
 recv_row_data(Sock, FieldList, SeqNum) ->
-	Tid = ets:new(emysql_row_data, [ordered_set, private]),
-	Res = recv_row_data(Sock, FieldList, SeqNum, Tid, 0),
-	ets:delete(Tid),
-	Res.
+        recv_row_data(Sock, FieldList, SeqNum, []).
 
-recv_row_data(Sock, FieldList, _SeqNum, Tid, Key) ->
+recv_row_data(Sock, FieldList, _SeqNum, Acc) ->
 	%-% io:format("~nreceive row ~p: ", [Key]),
 	case recv_packet(Sock) of
 		#packet{seq_num = SeqNum1, data = <<?RESP_EOF, _WarningCount:16/little, ServerStatus:16/little>>} ->
 			%-% io:format("- eof: ~p~n", [emysql_conn:hstate(ServerStatus)]),
-			{SeqNum1, ?ETS_SELECT(Tid), ServerStatus};
+                        {SeqNum1, lists:reverse(Acc), ServerStatus};
 		#packet{seq_num = SeqNum1, data = <<?RESP_EOF, _/binary>>} ->
 			%-% io:format("- eof.~n", []),
-			{SeqNum1, ?ETS_SELECT(Tid), ?SERVER_NO_STATUS};
+                        {SeqNum1, lists:reverse(Acc), ?SERVER_NO_STATUS};
 		#packet{seq_num = SeqNum1, data = RowData} ->
 			%-% io:format("Seq: ~p raw: ~p~n", [SeqNum1, RowData]),
 			Row = decode_row_data(RowData, FieldList, []),
-			ets:insert(Tid, {Key, Row}),
-			recv_row_data(Sock, FieldList, SeqNum1, Tid, Key+1)
+			recv_row_data(Sock, FieldList, SeqNum1, [Row|Acc])
 	end.
 
 decode_row_data(<<>>, [], Acc) ->

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -185,6 +185,9 @@ encode(Val, list, Encoding) when is_binary(Val) ->
 	quote(unicode:characters_to_list(Val, Encoding));
 
 
+encode(Val, binary, Encoding) when is_atom(Val) ->
+	encode(atom_to_list(Val), binary, Encoding);
+
 encode(Val, binary, latin1) when is_list(Val) -> 
 	list_to_binary(quote(Val));
 


### PR DESCRIPTION
Because some queries are (and will continue) to run long in  mysql database, allow  recv header timeout period to use the custom timeout.  This will reduce overall load in most cases - even when we exceed the original default of 8s, b/c it will reduce the client's need for retrying the same long query. 

@seth  @langloisjp could you take a quick look? 

NOTE: Originally I had used the custom timeout exactly, but that causes the timeout error to surface differently through the connection monitor - the timeout occurs in the monitor and not at the gen_tcp level, which woudl obscure the error in the case of an actual timeout.   
