### PR TITLE
Fix issues 57, 56, 48 and 39.

### DIFF
--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -222,8 +222,7 @@ encode(Val, list, _) when is_float(Val) ->
     Res;
 
 encode(Val, binary, _) when is_float(Val) ->
-    [Res] = io_lib:format("~w", [Val]),
-    Res;
+    iolist_to_binary(io_lib:format("~w", [Val]));
 
 encode({datetime, Val}, ReturnType, Encoding) ->
     encode(Val, ReturnType, Encoding);

--- a/test/basics_SUITE.erl
+++ b/test/basics_SUITE.erl
@@ -46,7 +46,8 @@ all() ->
      insert_and_read_back_as_recs,
      select_by_prepared_statement,
 	 delete_non_existant_procedure,
-	 select_by_stored_procedure].
+	 select_by_stored_procedure,
+     encode_floating_point_data].
 
 
 %% Optional suite pre test initialization
@@ -128,6 +129,18 @@ insert_and_read_back(_) ->
                [[<<"Hello World!">>]],
                <<>>},
     
+    ok.
+
+%% Test Case: Encode floating point data into a test table (Issue 57)
+encode_floating_point_data(_Config) ->
+    emysql:execute(test_pool, <<"DROP TABLE float_test">>),
+    emysql:execute(test_pool, <<"CREATE TABLE float_test ( x FLOAT )">>),
+    emysql:prepare(encode_float_stmt, <<"INSERT INTO float_test (x) VALUES (?)">>),
+    
+    Result = emysql:execute(test_pool, encode_float_stmt, [3.14]),
+
+    ct:log("Result: ~p", [Result]),
+    ok_packet = element(1, Result),
     ok.
 
 %% Test Case: Make an Insert and Select it back, reading out as Record


### PR DESCRIPTION
Binary encodes of floating point values are wrong in the code base
since they are encoded as lists. This makes the code crash. The mentioned
issues/pull requests assumes that io_lib is going to return a certain structure
however, but the only knowledge we have is that it will return an iolist().

While here, provide a test case for this kind of problem to ensure it does not
re-occur.
