### PR TITLE
Atom encoding

### DIFF
--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -184,9 +184,11 @@ encode(Val, list, latin1) when is_binary(Val) ->
 encode(Val, list, Encoding) when is_binary(Val) ->
     quote(unicode:characters_to_list(Val, Encoding));
 
+encode(Val, binary, Encoding) when is_atom(Val) ->
+	encode(atom_to_list(Val), binary, Encoding);
 
-encode(Val, binary, latin1) when is_list(Val) ->
-    list_to_binary(quote(Val));
+encode(Val, binary, latin1) when is_list(Val) -> 
+	list_to_binary(quote(Val));
 
 encode(Val, binary, Encoding) when is_list(Val) ->
     unicode:characters_to_binary(quote(Val), Encoding, Encoding);

--- a/test/basics_SUITE.erl
+++ b/test/basics_SUITE.erl
@@ -41,6 +41,7 @@ suite() ->
 
 all() -> 
     [delete_all,
+     encode_atoms,
      insert_only,
      insert_and_read_back,
      insert_and_read_back_as_recs,
@@ -103,6 +104,19 @@ insert_only(_) ->
     emysql:execute(test_pool,
         <<"INSERT INTO hello_table SET hello_text = 'Hello World!'">>),
 
+    ok.
+
+%% Test Case: Allow insertion of atom values through the encoder
+%%--------------------------------------------------------------------
+encode_atoms(_Config) ->
+    emysql:execute(test_pool, <<"DROP TABLE encode_atoms_test">>),
+    emysql:execute(test_pool, <<"CREATE TABLE encode_atoms_test (x VARCHAR(32))">>),
+
+    emysql:prepare(encode_atoms, <<"INSERT INTO encode_atoms_test (x) VALUES (?)">>),
+    Result = emysql:execute(test_pool, encode_atoms, [foo]),
+    ct:log("Result: ~p", [Result]),
+
+    ok_packet = element(1, Result),
     ok.
 
 %% Test Case: Make an Insert and Select it back


### PR DESCRIPTION
Yet another patch from the opscode guys. While here, provide a test case which fails before and succeeds after the application of their change.

I think it is rather sane if you can encode an atom name as a value directly into the MySQL driver. One would expect that the atom can be encoded like this.

There is one caveat though: In the future, atoms are likely to contain unicode data. We probably need a way to encode this later on via atom_to_binary(X, utf8) and so on. But I say, lets get this in and then handle those problems later, depending on how all our encoding woes pans out. One can always do the encoding to a binary oneself if it proves to be a problem, this is just a nice convenience.
