### PR TITLE
Fixed bug in emysql_tcp:recv_packet_body where it wasn't decrementing re...

### DIFF
--- a/src/emysql_tcp.erl
+++ b/src/emysql_tcp.erl
@@ -184,7 +184,7 @@ recv_packet_body(Sock, PacketLength, Acc) ->
         PacketLength > ?PACKETSIZE->
             case gen_tcp:recv(Sock, ?PACKETSIZE, ?TIMEOUT) of
                 {ok, Bin} ->
-                    recv_packet_body(Sock, PacketLength, [Bin|Acc]);
+                    recv_packet_body(Sock, PacketLength - ?PACKETSIZE, [Bin|Acc]);
                 {error, Reason1} ->
                     exit({failed_to_recv_packet_body, Reason1})
             end;


### PR DESCRIPTION
...quested number of bytes when reading from socket.

This one should go in. Otherwise we have a latent bug in the driver code. I'd much rather do a simple

```
 gen_tcp:recv(Socket, PacketLength, ?TIMEOUT)
```

on the socket and then just wait for all data to arrive directly like this, or time out after a while. Then go again and wait if `{error, timeout}` occurs. It is simpler, pushes work to the C layer, and is probably going to run a faster route than this.
