### PR TITLE
Fix csrl cleanup phase 1

### DIFF
--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -468,11 +468,11 @@ execute(PoolId, Query, Args, Timeout) when (is_list(Query) orelse is_binary(Quer
     %-% io:format("~p execute getting connection for pool id ~p~n",[self(), PoolId]),
     Connection = emysql_conn_mgr:wait_for_connection(PoolId),
     %-% io:format("~p execute got connection for pool id ~p: ~p~n",[self(), PoolId, Connection#emysql_connection.id]),
-    monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, Query, Args]});
+    monitor_work(Connection, Timeout, [Connection, Query, Args]);
 
 execute(PoolId, StmtName, Args, Timeout) when is_atom(StmtName), is_list(Args) andalso is_integer(Timeout) ->
     Connection = emysql_conn_mgr:wait_for_connection(PoolId),
-    monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, StmtName, Args]}).
+    monitor_work(Connection, Timeout, [Connection, StmtName, Args]).
 
 %% @spec execute(PoolId, Query|StmtName, Args, Timeout, nonblocking) -> Result | [Result]
 %%      PoolId = atom()
@@ -514,7 +514,7 @@ execute(PoolId, StmtName, Args, Timeout) when is_atom(StmtName), is_list(Args) a
 execute(PoolId, Query, Args, Timeout, nonblocking) when (is_list(Query) orelse is_binary(Query)) andalso is_list(Args) andalso is_integer(Timeout) ->
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
-            monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, Query, Args]});
+            monitor_work(Connection, Timeout, [Connection, Query, Args]);
         Other ->
             Other
     end;
@@ -522,7 +522,7 @@ execute(PoolId, Query, Args, Timeout, nonblocking) when (is_list(Query) orelse i
 execute(PoolId, StmtName, Args, Timeout, nonblocking) when is_atom(StmtName), is_list(Args) andalso is_integer(Timeout) ->
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
-            monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, StmtName, Args]});
+            monitor_work(Connection, Timeout, [Connection, StmtName, Args]);
         Other ->
             Other
     end.
@@ -557,14 +557,14 @@ execute(PoolId, StmtName, Args, Timeout, nonblocking) when is_atom(StmtName), is
 %% @private
 %% @end doc: hd feb 11
 %%
-monitor_work(Connection, Timeout, {M,F,A}) when is_record(Connection, emysql_connection) ->
+monitor_work(Connection, Timeout, Args) when is_record(Connection, emysql_connection) ->
     %% spawn a new process to do work, then monitor that process until
     %% it either dies, returns data or times out.
     Parent = self(),
     Pid = spawn(
         fun() ->
             receive start ->
-                Parent ! {self(), apply(M, F, A)}
+                Parent ! {self(), apply(fun emysql_conn:execute/3, Args)}
             end
         end),
     Mref = erlang:monitor(process, Pid),
@@ -575,9 +575,8 @@ monitor_work(Connection, Timeout, {M,F,A}) when is_record(Connection, emysql_con
             case emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection, keep) of
                 NewConnection when is_record(NewConnection, emysql_connection) ->
                     %% re-loop, with new connection.
-                    [_OldConn | RestArgs] = A,
-                    NewA = [NewConnection | RestArgs],
-                    monitor_work(NewConnection, Timeout, {M, F, NewA});
+                    [_ | OtherArgs] = Args,
+                    monitor_work(NewConnection, Timeout , [NewConnection | OtherArgs]);
                 {error, FailedReset} ->
                     exit({connection_down, {and_conn_reset_failed, FailedReset}})
             end;

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -515,16 +515,16 @@ execute(PoolId, Query, Args, Timeout, nonblocking) when (is_list(Query) orelse i
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
             monitor_work(Connection, Timeout, [Connection, Query, Args]);
-        Other ->
-            Other
+        unavailable ->
+            unavailable
     end;
 
 execute(PoolId, StmtName, Args, Timeout, nonblocking) when is_atom(StmtName), is_list(Args) andalso is_integer(Timeout) ->
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
             monitor_work(Connection, Timeout, [Connection, StmtName, Args]);
-        Other ->
-            Other
+        unavailable ->
+            unavailable
     end.
 
 %%--------------------------------------------------------------------

--- a/src/emysql_app.erl
+++ b/src/emysql_app.erl
@@ -39,19 +39,13 @@ start(_Type, _StartArgs) ->
     emysql_sup:start_link().
 
 stop(_State) ->
-    lists:foreach(
-        fun(Pool) ->
-            lists:foreach(
-                fun emysql_conn:close_connection/1,
-                lists:append(queue:to_list(Pool#pool.available), gb_trees:values(Pool#pool.locked))
-            )
-        end,
-        emysql_conn_mgr:pools()
-    ),
-    ok.
+	ok = lists:foreach(
+		fun (Pool) -> emysql:remove_pool(Pool#pool.pool_id) end,
+		emysql_conn_mgr:pools()).
 
 modules() ->
-    {ok, Modules} = application_controller:get_key(emysql, modules), Modules.
+	{ok, Modules} = application_controller:get_key(emysql, modules),
+	Modules.
 
 default_timeout() ->
     case application:get_env(emysql, default_timeout) of

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -130,7 +130,7 @@ open_connections(Pool) ->
     case (queue:len(Pool#pool.available) + gb_trees:size(Pool#pool.locked)) < Pool#pool.size of
         true ->
             %-% io:format(" continues~n"),
-            Conn = emysql_conn:open_connection(Pool),
+            Conn = open_connection(Pool),
             %-% io:format("opened connection: ~p~n", [Conn]),
             open_connections(Pool#pool{available = queue:in(Conn, Pool#pool.available)});
         false ->
@@ -164,8 +164,9 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
                 caps = Greeting#greeting.caps,
                 language = Greeting#greeting.language
             },
+
             %-% io:format("~p open connection: ... set db ...~n", [self()]),
-            case emysql_conn:set_database(Connection, Database) of
+            case set_database(Connection, Database) of
                 ok -> ok;
                 OK1 when is_record(OK1, ok_packet) ->
                      %-% io:format("~p open connection: ... db set ok~n", [self()]),
@@ -176,7 +177,7 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
                      exit({failed_to_set_database, Err1#error_packet.msg})
             end,
             %-% io:format("~p open connection: ... set encoding ...: ~p~n", [self(), Encoding]),
-            case emysql_conn:set_encoding(Connection, Encoding) of
+            case set_encoding(Connection, Encoding) of
                 OK2 when is_record(OK2, ok_packet) ->
                     ok;
                 Err2 when is_record(Err2, error_packet) ->

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -199,8 +199,7 @@ reset_connection(Pools, Conn, StayLocked) ->
     %% by the next caller process coming along. So the
     %% pool can't run dry, even though it can freeze.
     %-% io:format("resetting connection~n"),
-    %-% io:format("spawn process to close connection~n"),
-    spawn(fun() -> close_connection(Conn) end),
+    close_connection(Conn),
     %% OPEN NEW SOCKET
     case emysql_conn_mgr:find_pool(Conn#emysql_connection.pool_id, Pools) of
         {Pool, _} ->

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -224,11 +224,9 @@ reset_connection(Pools, Conn, StayLocked) ->
     end.
 
 close_connection(Conn) ->
-    %% DEALLOCATE PREPARED STATEMENTS
-    [(catch unprepare(Conn, Name)) || Name <- emysql_statements:remove(Conn#emysql_connection.id)],
-    %% CLOSE SOCKET
-    gen_tcp:close(Conn#emysql_connection.socket),
-    ok.
+	%% garbage collect statements
+	emysql_statements:remove(Conn#emysql_connection.id),
+	ok = gen_tcp:close(Conn#emysql_connection.socket).
 
 %%--------------------------------------------------------------------
 %%% Internal functions

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -382,12 +382,9 @@ pass_on_or_queue_as_available(State, Connection) ->
 
                     %% find connection in locked tree
                     case gb_trees:lookup(Connection#emysql_connection.id, Pool#pool.locked) of
-
-                        {value, Conn} ->
-
-                            %% add the connection to the 'available' queue and remove from 'locked' tree
+                        {value, _Conn} ->
                             Pool1 = Pool#pool{
-                                available = queue:in(Conn#emysql_connection{locked_at=undefined}, Pool#pool.available),
+								available = queue:in(Connection#emysql_connection{locked_at=undefined}, Pool#pool.available),
                                 locked = gb_trees:delete_any(Connection#emysql_connection.id, Pool#pool.locked)
                             },
                             {ok, State#state{pools = [Pool1|OtherPools]}};

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -237,8 +237,8 @@ handle_call({lock_connection, PoolId}, _From, State) ->
             case lock_next_connection(State, Pool, OtherPools) of
                 {ok, NewConn, State1} ->
                     {reply, NewConn, State1};
-                Other ->
-                    {reply, Other, State}
+                unavailable ->
+                    {reply, unavailable, State}
             end;
         undefined ->
             {reply, {error, pool_not_found}, State}


### PR DESCRIPTION
Here are 9 commits from @csrl which I believe are okay all of them. I have run tests and they pass but do note that many of these patches works on the connection pool management and that is not really tested that much by our current test code coverage.

I have run through all commit up to (but not including) https://github.com/csrl/emysql/commit/d1a7a2cd119b12cdde26de4651f30f0cea6db3fb .. So to continue we should start from there and take another phase of cleanups. While many of changes looks sound, they also messed a bit more when I tried to patch up the code base, so I need a fresh look later to continue on those.

Note that due to whitespace, many of the commits require some careful manual handling, so it is not that easy to get them in.
