### PR TITLE
Strip encoding code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,12 @@ test9: all
 prove: all
 	(cd t;$(MAKE))
 	prove t/*.t
+
+APPS = kernel stdlib erts crypto public_key ssl compiler asn1
+REPO = emysql
+COMBO_PLT = $(HOME)/.$(REPO)_combo_dialyzer_plt
+build_plt:
+	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS)
+
+dialyzer:
+	dialyzer --fullpath -nn --plt $(COMBO_PLT) ebin

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -594,12 +594,12 @@ monitor_work(Connection, Timeout, Args) when is_record(Connection, emysql_connec
             erlang:demonitor(Mref, [flush]),
             emysql_conn_mgr:pass_connection(Connection),
             Result
-        after Timeout ->
-            %% if we timeout waiting for the process to return,
-            %% then reset the connection and throw a timeout error
-            %-% io:format("monitor_work: ~p TIMEOUT -> demonitor, reset connection, exit~n", [Pid]),
-            erlang:demonitor(Mref),
-            exit(Pid, kill),
-            emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection),
-            exit(mysql_timeout)
+    after Timeout ->
+        %% if we timeout waiting for the process to return,
+        %% then reset the connection and throw a timeout error
+        %-% io:format("monitor_work: ~p TIMEOUT -> demonitor, reset connection, exit~n", [Pid]),
+        erlang:demonitor(Mref, [flush]),
+        exit(Pid, kill),
+        emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection, pass),
+        exit(mysql_timeout)
     end.

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -468,11 +468,11 @@ execute(PoolId, Query, Args, Timeout) when (is_list(Query) orelse is_binary(Quer
     %-% io:format("~p execute getting connection for pool id ~p~n",[self(), PoolId]),
     Connection = emysql_conn_mgr:wait_for_connection(PoolId),
     %-% io:format("~p execute got connection for pool id ~p: ~p~n",[self(), PoolId, Connection#emysql_connection.id]),
-    monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, Query, Args]});
+    monitor_work(Connection, Timeout, [Connection, Query, Args]);
 
 execute(PoolId, StmtName, Args, Timeout) when is_atom(StmtName), is_list(Args) andalso is_integer(Timeout) ->
     Connection = emysql_conn_mgr:wait_for_connection(PoolId),
-    monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, StmtName, Args]}).
+    monitor_work(Connection, Timeout, [Connection, StmtName, Args]).
 
 %% @spec execute(PoolId, Query|StmtName, Args, Timeout, nonblocking) -> Result | [Result]
 %%      PoolId = atom()
@@ -514,7 +514,7 @@ execute(PoolId, StmtName, Args, Timeout) when is_atom(StmtName), is_list(Args) a
 execute(PoolId, Query, Args, Timeout, nonblocking) when (is_list(Query) orelse is_binary(Query)) andalso is_list(Args) andalso is_integer(Timeout) ->
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
-            monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, Query, Args]});
+            monitor_work(Connection, Timeout, [Connection, Query, Args]);
         Other ->
             Other
     end;
@@ -522,7 +522,7 @@ execute(PoolId, Query, Args, Timeout, nonblocking) when (is_list(Query) orelse i
 execute(PoolId, StmtName, Args, Timeout, nonblocking) when is_atom(StmtName), is_list(Args) andalso is_integer(Timeout) ->
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
-            monitor_work(Connection, Timeout, {emysql_conn, execute, [Connection, StmtName, Args]});
+            monitor_work(Connection, Timeout, [Connection, StmtName, Args]);
         Other ->
             Other
     end.
@@ -557,14 +557,14 @@ execute(PoolId, StmtName, Args, Timeout, nonblocking) when is_atom(StmtName), is
 %% @private
 %% @end doc: hd feb 11
 %%
-monitor_work(Connection, Timeout, {M,F,A}) when is_record(Connection, emysql_connection) ->
+monitor_work(Connection, Timeout, Args) when is_record(Connection, emysql_connection) ->
     %% spawn a new process to do work, then monitor that process until
     %% it either dies, returns data or times out.
     Parent = self(),
     Pid = spawn(
         fun() ->
             receive start ->
-                Parent ! {self(), apply(M, F, A)}
+                Parent ! {self(), apply(fun emysql_conn:execute/3, Args)}
             end
         end),
     Mref = erlang:monitor(process, Pid),
@@ -575,9 +575,8 @@ monitor_work(Connection, Timeout, {M,F,A}) when is_record(Connection, emysql_con
             case emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection, keep) of
                 NewConnection when is_record(NewConnection, emysql_connection) ->
                     %% re-loop, with new connection.
-                    [_OldConn | RestArgs] = A,
-                    NewA = [NewConnection | RestArgs],
-                    monitor_work(NewConnection, Timeout, {M, F, NewA});
+                    [_ | OtherArgs] = Args,
+                    monitor_work(NewConnection, Timeout , [NewConnection | OtherArgs]);
                 {error, FailedReset} ->
                     exit({connection_down, {and_conn_reset_failed, FailedReset}})
             end;

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -515,16 +515,16 @@ execute(PoolId, Query, Args, Timeout, nonblocking) when (is_list(Query) orelse i
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
             monitor_work(Connection, Timeout, [Connection, Query, Args]);
-        Other ->
-            Other
+        unavailable ->
+            unavailable
     end;
 
 execute(PoolId, StmtName, Args, Timeout, nonblocking) when is_atom(StmtName), is_list(Args) andalso is_integer(Timeout) ->
     case emysql_conn_mgr:lock_connection(PoolId) of
         Connection when is_record(Connection, emysql_connection) ->
             monitor_work(Connection, Timeout, [Connection, StmtName, Args]);
-        Other ->
-            Other
+        unavailable ->
+            unavailable
     end.
 
 %%--------------------------------------------------------------------

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -562,9 +562,10 @@ monitor_work(Connection, Timeout, Args) when is_record(Connection, emysql_connec
     %% it either dies, returns data or times out.
     Parent = self(),
     {Pid, Mref} = spawn_monitor(
-        fun() ->
-                Parent ! {self(), apply(fun emysql_conn:execute/3, Args)}
-        end),
+                    fun() ->
+                            put(query_arguments, Args),
+                            Parent ! {self(), apply(fun emysql_conn:execute/3, Args)}
+                    end),
     receive
         {'DOWN', Mref, process, Pid, {_, closed}} ->
             %-% io:format("monitor_work: ~p DOWN/closed -> renew~n", [Pid]),

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -561,14 +561,10 @@ monitor_work(Connection, Timeout, Args) when is_record(Connection, emysql_connec
     %% spawn a new process to do work, then monitor that process until
     %% it either dies, returns data or times out.
     Parent = self(),
-    Pid = spawn(
+    {Pid, Mref} = spawn_monitor(
         fun() ->
-            receive start ->
                 Parent ! {self(), apply(fun emysql_conn:execute/3, Args)}
-            end
         end),
-    Mref = erlang:monitor(process, Pid),
-    Pid ! start,
     receive
         {'DOWN', Mref, process, Pid, {_, closed}} ->
             %-% io:format("monitor_work: ~p DOWN/closed -> renew~n", [Pid]),

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -603,9 +603,7 @@ monitor_work(Connection, Timeout, Args) when is_record(Connection, emysql_connec
             %% then reset the connection and throw a timeout error
             %-% io:format("monitor_work: ~p TIMEOUT -> demonitor, reset connection, exit~n", [Pid]),
             erlang:demonitor(Mref),
-            case emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection, pass) of
-                {error, FailedReset} ->
-                    exit({mysql_timeout, Timeout, {and_conn_reset_failed, FailedReset}});
-                _ -> exit({mysql_timeout, Timeout, {}})
-            end
+            exit(Pid, kill),
+            emysql_conn:reset_connection(emysql_conn_mgr:pools(), Connection),
+            exit(mysql_timeout)
     end.

--- a/src/emysql_app.erl
+++ b/src/emysql_app.erl
@@ -39,19 +39,13 @@ start(_Type, _StartArgs) ->
     emysql_sup:start_link().
 
 stop(_State) ->
-    lists:foreach(
-        fun(Pool) ->
-            lists:foreach(
-                fun emysql_conn:close_connection/1,
-                lists:append(queue:to_list(Pool#pool.available), gb_trees:values(Pool#pool.locked))
-            )
-        end,
-        emysql_conn_mgr:pools()
-    ),
-    ok.
+	ok = lists:foreach(
+		fun (Pool) -> emysql:remove_pool(Pool#pool.pool_id) end,
+		emysql_conn_mgr:pools()).
 
 modules() ->
-    {ok, Modules} = application_controller:get_key(emysql, modules), Modules.
+	{ok, Modules} = application_controller:get_key(emysql, modules),
+	Modules.
 
 default_timeout() ->
     case application:get_env(emysql, default_timeout) of

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -214,7 +214,7 @@ reset_connection(Pools, Conn, StayLocked) ->
                 #emysql_connection{} = NewConn ->
                     emysql_conn_mgr:replace_connection(Conn, NewConn);
                 {'EXIT' ,Reason} ->
-                    emysql_conn_mgr:unlock_connection(Conn),
+                    emysql_conn_mgr:pass_connection(Conn),
                     exit(Reason)
             end;
         undefined ->

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -129,10 +129,12 @@ open_connections(Pool) ->
      %-% io:format("open connections loop: .. "),
     case (queue:len(Pool#pool.available) + gb_trees:size(Pool#pool.locked)) < Pool#pool.size of
         true ->
-            %-% io:format(" continues~n"),
-            Conn = open_connection(Pool),
-            %-% io:format("opened connection: ~p~n", [Conn]),
-            open_connections(Pool#pool{available = queue:in(Conn, Pool#pool.available)});
+            case catch open_connection(Pool) of
+                #emysql_connection{} = Conn ->
+                    open_connections(Pool#pool{available = queue:in(Conn, Pool#pool.available)});
+				_ ->
+					Pool
+			end;
         false ->
             %-% io:format(" done~n"),
             Pool

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -223,7 +223,7 @@ reset_connection(Pools, Conn, StayLocked) ->
 
 renew_connection(Pools, Conn) ->
 	close_connection(Conn),
-	case emysql_conn_mgr:find_pool(Conn#emysql_connection.pool_id, Pools, []) of
+	case emysql_conn_mgr:find_pool(Conn#emysql_connection.pool_id, Pools) of
 		{Pool, _} ->
 			case catch open_connection(Pool) of
 				#emysql_connection{} = NewConn ->

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -230,7 +230,6 @@ close_connection(Conn) ->
 %%% Internal functions
 %%--------------------------------------------------------------------
 set_params(_, _, [], Result) -> Result;
-set_params(_, _, _, Error) when is_record(Error, error_packet) -> Error;
 set_params(Connection, Num, Values, _) ->
 	Packet = set_params_packet(Num, Values, Connection#emysql_connection.encoding),
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -191,10 +191,7 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
         {error, Reason} ->
              %-% io:format("~p open connection: ... ERROR ~p~n", [self(), Reason]),
              %-% io:format("~p open connection: ... exit with failed_to_connect_to_database~n", [self()]),
-            exit({failed_to_connect_to_database, Reason});
-        What ->
-             %-% io:format("~p open connection: ... UNKNOWN ERROR ~p~n", [self(), What]),
-            exit({unknown_fail, What})
+            exit({failed_to_connect_to_database, Reason})
     end.
 
 reset_connection(Pools, Conn, StayLocked) ->

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -130,7 +130,7 @@ open_connections(Pool) ->
     case (queue:len(Pool#pool.available) + gb_trees:size(Pool#pool.locked)) < Pool#pool.size of
         true ->
             %-% io:format(" continues~n"),
-            Conn = emysql_conn:open_connection(Pool),
+            Conn = open_connection(Pool),
             %-% io:format("opened connection: ~p~n", [Conn]),
             open_connections(Pool#pool{available = queue:in(Conn, Pool#pool.available)});
         false ->
@@ -164,8 +164,9 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
                 caps = Greeting#greeting.caps,
                 language = Greeting#greeting.language
             },
+
             %-% io:format("~p open connection: ... set db ...~n", [self()]),
-            case emysql_conn:set_database(Connection, Database) of
+            case set_database(Connection, Database) of
                 ok -> ok;
                 OK1 when is_record(OK1, ok_packet) ->
                      %-% io:format("~p open connection: ... db set ok~n", [self()]),
@@ -176,7 +177,7 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
                      exit({failed_to_set_database, Err1#error_packet.msg})
             end,
             %-% io:format("~p open connection: ... set encoding ...: ~p~n", [self(), Encoding]),
-            case emysql_conn:set_encoding(Connection, Encoding) of
+            case set_encoding(Connection, Encoding) of
                 OK2 when is_record(OK2, ok_packet) ->
                     ok;
                 Err2 when is_record(Err2, error_packet) ->

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -146,11 +146,11 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
     case gen_tcp:connect(Host, Port, [binary, {packet, raw}, {active, false}]) of
         {ok, Sock} ->
 			Greeting = case catch emysql_auth:do_handshake(Sock, User, Password) of
-				{'EXIT', ExitReason} ->
-                          gen_tcp:close(Sock),
+                {'EXIT', ExitReason} ->
+                    gen_tcp:close(Sock),
 					exit(ExitReason);
 				Greeting0 -> Greeting0
-			      end,
+			end,
             Connection = #emysql_connection{
                 id = erlang:port_to_list(Sock),
                 pool_id = PoolId,
@@ -169,9 +169,9 @@ open_connection(#pool{pool_id=PoolId, host=Host, port=Port, user=User, password=
                      %-% io:format("~p open connection: ... db set ok~n", [self()]),
                     ok;
                 Err1 when is_record(Err1, error_packet) ->
-                     %-% io:format("~p open connection: ... db set error~n", [self()]),
-                     gen_tcp:close(Sock),
-                     exit({failed_to_set_database, Err1#error_packet.msg})
+                    %-% io:format("~p open connection: ... db set error~n", [self()]),
+                    gen_tcp:close(Sock),
+                    exit({failed_to_set_database, Err1#error_packet.msg})
             end,
             %-% io:format("~p open connection: ... set encoding ...: ~p~n", [self(), Encoding]),
             case set_encoding(Connection, Encoding) of
@@ -287,7 +287,6 @@ prepare_statement(Connection, StmtName) ->
 % human readable string rep of the server state flag
 %% @private
 hstate(State) ->
-
-       case (State band ?SERVER_STATUS_AUTOCOMMIT) of 0 -> ""; _-> "AUTOCOMMIT " end
-    ++ case (State band ?SERVER_MORE_RESULTS_EXIST) of 0 -> ""; _-> "MORE_RESULTS_EXIST " end
+       case (State band ?SERVER_STATUS_AUTOCOMMIT)   of 0 -> ""; _-> "AUTOCOMMIT " end
+    ++ case (State band ?SERVER_MORE_RESULTS_EXIST)  of 0 -> ""; _-> "MORE_RESULTS_EXIST " end
     ++ case (State band ?SERVER_QUERY_NO_INDEX_USED) of 0 -> ""; _-> "NO_INDEX_USED " end.

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -222,9 +222,11 @@ reset_connection(Pools, Conn, StayLocked) ->
         {Pool, _} ->
             case catch open_connection(Pool) of
                 #emysql_connection{} = NewConn when StayLocked == pass ->
-                    emysql_conn_mgr:replace_connection_as_available(Conn, NewConn);
+                    ok = emysql_conn_mgr:replace_connection_as_available(Conn, NewConn),
+                    NewConn;
                 #emysql_connection{} = NewConn when StayLocked == keep ->
-                    emysql_conn_mgr:replace_connection_as_locked(Conn, NewConn);
+                    ok = emysql_conn_mgr:replace_connection_as_locked(Conn, NewConn),
+                    NewConn;
                 {'EXIT', Reason} ->
                     DeadConn = Conn#emysql_connection { alive = false },
                     emysql_conn_mgr:replace_connection_as_available(Conn, DeadConn),

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -199,8 +199,7 @@ reset_connection(Pools, Conn, StayLocked) ->
     %% by the next caller process coming along. So the
     %% pool can't run dry, even though it can freeze.
     %-% io:format("resetting connection~n"),
-    %-% io:format("spawn process to close connection~n"),
-    spawn(fun() -> close_connection(Conn) end),
+    close_connection(Conn),
     %% OPEN NEW SOCKET
     case emysql_conn_mgr:find_pool(Conn#emysql_connection.pool_id, Pools) of
         {Pool, _} ->

--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -224,11 +224,9 @@ reset_connection(Pools, Conn, StayLocked) ->
     end.
 
 close_connection(Conn) ->
-    %% DEALLOCATE PREPARED STATEMENTS
-    [(catch unprepare(Conn, Name)) || Name <- emysql_statements:remove(Conn#emysql_connection.id)],
-    %% CLOSE SOCKET
-    gen_tcp:close(Conn#emysql_connection.socket),
-    ok.
+	%% garbage collect statements
+	emysql_statements:remove(Conn#emysql_connection.id),
+	ok = gen_tcp:close(Conn#emysql_connection.socket).
 
 %%--------------------------------------------------------------------
 %%% Internal functions

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -37,7 +37,7 @@
         lock_connection/1, wait_for_connection/1, wait_for_connection/2,
         pass_connection/1,
         replace_connection_as_available/2, replace_connection_as_locked/2,
-        find_pool/2]).
+        find_pool/2, give_manager_control/1]).
 
 -include("emysql.hrl").
 
@@ -104,6 +104,12 @@ replace_connection_as_available(OldConn, NewConn) ->
 
 replace_connection_as_locked(OldConn, NewConn) ->
     do_gen_call({replace_connection_as_locked, OldConn, NewConn}).
+
+give_manager_control(Socket) ->
+	case whereis(?MODULE) of
+		undefined -> {error ,failed_to_find_conn_mgr};
+		MgrPid -> gen_tcp:controlling_process(Socket, MgrPid)
+	end.
 
 %% the stateful loop functions of the gen_server never
 %% want to call exit/1 because it would crash the gen_server.

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -251,11 +251,12 @@ handle_call({{replace_connection, Kind}, OldConn, NewConn}, _From, State) ->
                            serve_waiting_pids(
                              Pool#pool { locked = Stripped,
                                          available = queue:in(
-                                            NewConn#emysql_connection { locked_at = undefined},
+                                            NewConn#emysql_connection { locked_at = undefined },
                                             Available) }),
                          {ok, ServedPool};
                        locked ->
                          {ok, Pool#pool { locked = gb_trees:enter(NewConn#emysql_connection.id,
+                                                                  NewConn,
                                                                   Stripped) }}
                     end
                 end,

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -35,7 +35,7 @@
 -export([pools/0, add_pool/1, remove_pool/1,
         add_connections/2, remove_connections/2,
         lock_connection/1, wait_for_connection/1, wait_for_connection/2,
-        pass_connection/1,
+        pass_connection/1, replace_connection_as_locked/2, replace_connection_as_available/2,
         find_pool/2, give_manager_control/1]).
 
 -include("emysql.hrl").

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -382,12 +382,9 @@ pass_on_or_queue_as_available(State, Connection) ->
 
                     %% find connection in locked tree
                     case gb_trees:lookup(Connection#emysql_connection.id, Pool#pool.locked) of
-
-                        {value, Conn} ->
-
-                            %% add the connection to the 'available' queue and remove from 'locked' tree
+                        {value, _Conn} ->
                             Pool1 = Pool#pool{
-                                available = queue:in(Conn#emysql_connection{locked_at=undefined}, Pool#pool.available),
+								available = queue:in(Connection#emysql_connection{locked_at=undefined}, Pool#pool.available),
                                 locked = gb_trees:delete_any(Connection#emysql_connection.id, Pool#pool.locked)
                             },
                             {ok, State#state{pools = [Pool1|OtherPools]}};

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -78,7 +78,7 @@ wait_for_connection(PoolId ,Timeout)->
     %% try to lock a connection. if no connections are available then
     %% wait to be notified of the next available connection
     %-% io:format("~p waits for connection to pool ~p~n", [self(), PoolId]),
-        case do_gen_call({lock_connection, PoolId, true}) of
+    case do_gen_call({lock_connection, PoolId, true}) of
         unavailable ->
             %-% io:format("~p is queued~n", [self()]),
             receive
@@ -210,7 +210,7 @@ handle_call({lock_connection, PoolId, Wait}, {From, _Mref}, State) ->
             {reply, {error, pool_not_found}, State}
     end;
 
-handle_call({end_wait, PoolId}, {From, _Mref}, State) ->
+handle_call({abort_wait, PoolId}, {From, _Mref}, State) ->
     case find_pool(PoolId, State#state.pools) of
         {Pool, OtherPools} ->
             %% Remove From from the wait queue

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -195,10 +195,10 @@ handle_call({remove_connections, PoolId, Num}, _From, State) ->
 handle_call({lock_connection, PoolId, Wait}, {From, _Mref}, State) ->
     case find_pool(PoolId, State#state.pools) of
         {Pool, OtherPools} ->
-			case lock_next_connection(Pool) of
-				{ok, Connection, PoolNow} ->
-					{reply, Connection, State#state{pools=[PoolNow|OtherPools]}};
-				unavailable when Wait =:= true ->
+            case lock_next_connection(Pool) of
+                {ok, Connection, PoolNow} ->
+                    {reply, Connection, State#state{pools=[PoolNow|OtherPools]}};
+                unavailable when Wait =:= true ->
                     %% place the calling pid at the end of the waiting queue of its pool
                     PoolNow = Pool#pool{waiting = queue:in(From, Pool#pool.waiting)},
                     {reply, unavailable, State#state{pools=[PoolNow|OtherPools]}};

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -237,8 +237,8 @@ handle_call({lock_connection, PoolId}, _From, State) ->
             case lock_next_connection(State, Pool, OtherPools) of
                 {ok, NewConn, State1} ->
                     {reply, NewConn, State1};
-                Other ->
-                    {reply, Other, State}
+                unavailable ->
+                    {reply, unavailable, State}
             end;
         undefined ->
             {reply, {error, pool_not_found}, State}

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -36,7 +36,6 @@
         add_connections/2, remove_connections/2,
         lock_connection/1, wait_for_connection/1, wait_for_connection/2,
         pass_connection/1,
-        replace_connection_as_available/2, replace_connection_as_locked/2,
         find_pool/2, give_manager_control/1]).
 
 -include("emysql.hrl").

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -24,9 +24,8 @@
 %% OTHER DEALINGS IN THE SOFTWARE.
 -module(emysql_util).
 -export([field_names/1, as_record/4, as_record/3, length_coded_binary/1, length_coded_string/1,
-    null_terminated_string/2, asciz/1, bxor_binary/2, dualmap/3, hash/1,
+    null_terminated_string/2, asciz/1, bxor_binary/2, dualmap/3, hash/1, to_binary/1,
     rnd/3, encode/1, encode/2, quote/1]).
--compile(export_all).
 
 -include("emysql.hrl").
 

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -276,7 +276,7 @@ quote(String) when is_list(String) ->
 quote(String, _) when is_list(String) ->
     quote(String);
 
-quote(Any, Pool) when is_record(Any,pool) ->
+quote(Any, Pool) when is_record(Pool,pool) ->
     quote(Any, Pool#pool.encoding);
 
 quote(Bin, latin1) when is_binary(Bin) ->

--- a/test/basics_SUITE.erl
+++ b/test/basics_SUITE.erl
@@ -133,7 +133,7 @@ insert_and_read_back(_) ->
         <<"select hello_text from hello_table">>),
 	
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("~p~n", [Result]),
+	ct:log("~p~n", [Result]),
 
 	% the test
 	Result = {result_packet,5,
@@ -172,7 +172,7 @@ insert_and_read_back_as_recs(_) ->
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("~p~n", [Recs]),
+	ct:log("~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -195,7 +195,7 @@ select_by_prepared_statement(_) ->
 	Result = emysql:execute(test_pool, test_stmt, ["Hello%"]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	% the test
 	Result = {result_packet,5,
@@ -219,7 +219,7 @@ delete_non_existant_procedure(_) ->
 	  	% note: returns ok even if sp_hello does not exist
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("~p~n", [Result1]),
+	ct:log("~p~n", [Result1]),
 
 	% test
 	Result1 = {error_packet,1,1305,<<"42000">>,
@@ -241,7 +241,7 @@ select_by_stored_procedure(_) ->
 	  	% note: returns ok even if sp_hello does not exist
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("~p~n", [Result1]),
+	ct:log("~p~n", [Result1]),
 
 	% first test
 	case Result1 of
@@ -254,7 +254,7 @@ select_by_stored_procedure(_) ->
 	  	<<"create procedure sp_hello() begin select * from hello_table limit 2; end">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("~p~n", [Result2]),
+	ct:log("~p~n", [Result2]),
 
 	% second test
 	{ok_packet,1,0,0,_,0,[]} = Result2,
@@ -263,7 +263,7 @@ select_by_stored_procedure(_) ->
 	   	<<"call sp_hello();">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("~p~n", [Result3]),
+	ct:log("~p~n", [Result3]),
 	
 	% third, main test
 	[{result_packet,5,

--- a/test/conn_mgr_SUITE.erl
+++ b/test/conn_mgr_SUITE.erl
@@ -127,8 +127,8 @@ stuck_waiting_2(_) ->
     % find needed time for the sql command
     {Micro, _} = timer:tc(?MODULE, ?TRY_RACE, [1]),
     Timeout = trunc(Micro / 1000 * LenienceFactor) + 100,
-    io:format("Seen execution time: ~p µs (microseconds)~n", [Micro]),
-    io:format("Set timeout: ~p ms (milliseconds)~n", [Timeout]),
+    ct:log("Seen execution time: ~p ï¿½s (microseconds)~n", [Micro]),
+    ct:log("Set timeout: ~p ms (milliseconds)~n", [Timeout]),
 
     %% Warn about time when run with actual MySQL query for TRY_RACE.
     Timeout > 5000 andalso
@@ -143,10 +143,10 @@ stuck_waiting_2(_) ->
      || _ <- lists:seq(1,Processes)],
     [receive
 	 {'EXIT', _, normal} -> 
-	    io:format("One process complete, other could now use connections.", []);
+	    ct:log("One process complete, other could now use connections.", []);
 	 {'EXIT', _, connection_lock_timeout} -> 
-	    io:format("One process exits stuck in timeout.", []),
-	    io:format("Timout was set to ~pms to be sure it can even outlast complete starvation by the other process and really indicatetes that even a free connection could be assigned to this process. Loops: ~p, used time for one sample SQL operation: ~p ms.", 
+	    ct:log("One process exits stuck in timeout.", []),
+	    ct:log("Timout was set to ~pms to be sure it can even outlast complete starvation by the other process and really indicatetes that even a free connection could be assigned to this process. Loops: ~p, used time for one sample SQL operation: ~p ms.", 
 	    [Timeout, Loops, Micro/1000]),
 	    exit(issue9_stuck_waiting);
 	 {'EXIT', _, Reason} -> exit({unexpected_error, Reason})
@@ -175,7 +175,7 @@ pool_leak_2(_) ->
     
     %% find this output via test/index.html
     [Pool] = emysql_conn_mgr:pools(),
-    io:format("Pool available at start: ~p~n", [Pool#pool.available]),
+    ct:log("Pool available at start: ~p~n", [Pool#pool.available]),
 
     %% preliminary test
     {[{emysql_connection, _,test_pool,_,_,_,_,_,_,{0,nil}, undefined,true}], 
@@ -195,7 +195,7 @@ pool_leak_2(_) ->
 
     %% Test if pool still has one connection (and available)
     [Pool1] = emysql_conn_mgr:pools(),
-    io:format("Pool available after test: ~p~n", [Pool1#pool.available]),
+    ct:log("Pool available after test: ~p~n", [Pool1#pool.available]),
     case Pool1#pool.available of
         {[{emysql_connection, _,test_pool,_,_,_,_,_,_,{0,nil}, undefined,true}],
          []} -> ok;

--- a/test/environment_SUITE.erl
+++ b/test/environment_SUITE.erl
@@ -83,5 +83,5 @@ insert_a_record(_) ->
 select_a_record(_) ->
     Result = emysql:execute(environment_test_pool,
         <<"select hello_text from hello_table">>),
-    io:format("~n~p~n", [Result]),
+    ct:log("~n~p~n", [Result]),
     ok.

--- a/test/latin_SUITE.erl
+++ b/test/latin_SUITE.erl
@@ -469,13 +469,13 @@ insert_and_read_back_as_recs(_) ->
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -498,13 +498,13 @@ select_by_prepared_statement(_) ->
 	Result = emysql:execute(test_pool, test_stmt, ["Hello%"]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -512,7 +512,7 @@ select_by_prepared_statement(_) ->
 	[{hello_record,BinString}] = Recs,
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result String (latin-1 string): ~ts~n", [BinString]),
+	ct:log("Result String (latin-1 string): ~ts~n", [BinString]),
 
 	% the test
 	BinString = <<"Hello World!">>,
@@ -537,24 +537,24 @@ read_back_directly(Value) when is_list(Value) ->
 read_back_directly(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
-	% io:format("                           expecting (unicode): ~ts~n", [Value]),
-	io:format("                           expecting (integer): ~w~n", [Value]),
+	ct:log("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
+	% ct:log("                           expecting (unicode): ~ts~n", [Value]),
+	ct:log("                           expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record, ResultBin}] = Recs,
-   	io:format("Result String: ~w~n", [ResultBin]),
+   	ct:log("Result String: ~w~n", [ResultBin]),
 
 	% the test
  	ResultBin = Value,
@@ -573,20 +573,20 @@ read_back_by_statement(Value) when is_list(Value) ->
 read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
+	ct:log("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
 	
-	io:format("                                        expecting (integer): ~w~n", [Value]),
+	ct:log("                                        expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, stmt_select),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record, Value}],
@@ -594,7 +594,7 @@ read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record,BinString}] = Recs,
-	io:format("Result String: ~w~n", [BinString]),
+	ct:log("Result String: ~w~n", [BinString]),
 
 	% the test
 	BinString = Value,
@@ -718,15 +718,15 @@ test_latin1_liststring_via_parameter(_) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
-	io:format("******************************************~n", []),
+	ct:log("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
+	ct:log("******************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
 
 	X = emysql_util:any_to_binary(["INSERT INTO hello_table SET hello_text = ",
 			emysql_util:quote(Value,QuoteEncoding)]),
 
-	io:format("=> ~p = ~w.~n", [X,X]),
+	ct:log("=> ~p = ~w.~n", [X,X]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -743,12 +743,12 @@ worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as direct insert statement.~n", []),
-	io:format("**********************************************~n", []),
+	ct:log("Worker: write liststring as direct insert statement.~n", []),
+	ct:log("**********************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
 
-	io:format("Binary: ~p = ~w.~n", [Binary,Binary]),
+	ct:log("Binary: ~p = ~w.~n", [Binary,Binary]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -765,18 +765,18 @@ worker_direct_insert(Value, Binary) when is_list(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as parameter to prepared insert statement.~n", []),
-	io:format("*********************************************************~n", []),
+	ct:log("Worker: write binary as parameter to prepared insert statement.~n", []),
+	ct:log("*********************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Expect),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Expect),
 
@@ -786,18 +786,18 @@ worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as parameter to prepared insert statement.~n", []),
-	io:format("*************************************************************~n", []),
+	ct:log("Worker: write liststring as parameter to prepared insert statement.~n", []),
+	ct:log("*************************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Binary),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Binary),
 

--- a/test/latin_to_utf8db_SUITE.erl
+++ b/test/latin_to_utf8db_SUITE.erl
@@ -468,13 +468,13 @@ insert_and_read_back_as_recs(_) ->
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -497,13 +497,13 @@ select_by_prepared_statement(_) ->
 	Result = emysql:execute(test_pool, test_stmt, ["Hello%"]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -511,7 +511,7 @@ select_by_prepared_statement(_) ->
 	[{hello_record,BinString}] = Recs,
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result String (latin-1 string): ~ts~n", [BinString]),
+	ct:log("Result String (latin-1 string): ~ts~n", [BinString]),
 
 	% the test
 	BinString = <<"Hello World!">>,
@@ -536,24 +536,24 @@ read_back_directly(Value) when is_list(Value) ->
 read_back_directly(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
-	% io:format("                           expecting (unicode): ~ts~n", [Value]),
-	io:format("                           expecting (integer): ~w~n", [Value]),
+	ct:log("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
+	% ct:log("                           expecting (unicode): ~ts~n", [Value]),
+	ct:log("                           expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record, ResultBin}] = Recs,
-   	io:format("Result String: ~w~n", [ResultBin]),
+   	ct:log("Result String: ~w~n", [ResultBin]),
 
 	% the test
  	ResultBin = Value,
@@ -572,20 +572,20 @@ read_back_by_statement(Value) when is_list(Value) ->
 read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
+	ct:log("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
 	
-	io:format("                                        expecting (integer): ~w~n", [Value]),
+	ct:log("                                        expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, stmt_select),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record, Value}],
@@ -593,7 +593,7 @@ read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record,BinString}] = Recs,
-	io:format("Result String: ~w~n", [BinString]),
+	ct:log("Result String: ~w~n", [BinString]),
 
 	% the test
 	BinString = Value,
@@ -717,15 +717,15 @@ test_latin1_liststring_via_parameter(_) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
-	io:format("******************************************~n", []),
+	ct:log("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
+	ct:log("******************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
 
 	X = emysql_util:any_to_binary(["INSERT INTO hello_table SET hello_text = ",
 			emysql_util:quote(Value,QuoteEncoding)]),
 
-	io:format("=> ~p = ~w.~n", [X,X]),
+	ct:log("=> ~p = ~w.~n", [X,X]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -742,12 +742,12 @@ worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as direct insert statement.~n", []),
-	io:format("**********************************************~n", []),
+	ct:log("Worker: write liststring as direct insert statement.~n", []),
+	ct:log("**********************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
 
-	io:format("Binary: ~p = ~w.~n", [Binary,Binary]),
+	ct:log("Binary: ~p = ~w.~n", [Binary,Binary]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -764,18 +764,18 @@ worker_direct_insert(Value, Binary) when is_list(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as parameter to prepared insert statement.~n", []),
-	io:format("*********************************************************~n", []),
+	ct:log("Worker: write binary as parameter to prepared insert statement.~n", []),
+	ct:log("*********************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Expect),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Expect),
 
@@ -785,18 +785,18 @@ worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as parameter to prepared insert statement.~n", []),
-	io:format("*************************************************************~n", []),
+	ct:log("Worker: write liststring as parameter to prepared insert statement.~n", []),
+	ct:log("*************************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Binary),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Binary),
 

--- a/test/utf8_SUITE.erl
+++ b/test/utf8_SUITE.erl
@@ -448,13 +448,13 @@ insert_and_read_back_as_recs(_) ->
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -477,13 +477,13 @@ select_by_prepared_statement(_) ->
 	Result = emysql:execute(test_pool, test_stmt, ["Hello%"]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -491,7 +491,7 @@ select_by_prepared_statement(_) ->
 	[{hello_record,BinString}] = Recs,
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result String (latin-1 string): ~ts~n", [BinString]),
+	ct:log("Result String (latin-1 string): ~ts~n", [BinString]),
 
 	% the test
 	BinString = <<"Hello World!">>,
@@ -516,24 +516,24 @@ read_back_directly(Value) when is_list(Value) ->
 read_back_directly(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
-	% io:format("                           expecting (unicode): ~ts~n", [Value]),
-	io:format("                           expecting (integer): ~w~n", [Value]),
+	ct:log("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
+	% ct:log("                           expecting (unicode): ~ts~n", [Value]),
+	ct:log("                           expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record, ResultBin}] = Recs,
-   	io:format("Result String: ~w~n", [ResultBin]),
+   	ct:log("Result String: ~w~n", [ResultBin]),
 
 	% the test
  	Value = ResultBin,
@@ -551,20 +551,20 @@ read_back_by_statement(Value) when is_list(Value) ->
 read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
+	ct:log("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
 	
-	io:format("                                        expecting (integer): ~w~n", [Value]),
+	ct:log("                                        expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, stmt_select),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record, Value}],
@@ -572,7 +572,7 @@ read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record,BinString}] = Recs,
-	io:format("Result String: ~w~n", [BinString]),
+	ct:log("Result String: ~w~n", [BinString]),
 
 	% the test
 	BinString = Value,
@@ -696,15 +696,15 @@ test_latin1_liststring_via_parameter(_) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
-	io:format("******************************************~n", []),
+	ct:log("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
+	ct:log("******************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
 
 	X = emysql_util:any_to_binary(["INSERT INTO hello_table SET hello_text = ",
 			emysql_util:quote(Value,QuoteEncoding)]),
 
-	io:format("=> ~p = ~w.~n", [X,X]),
+	ct:log("=> ~p = ~w.~n", [X,X]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -721,12 +721,12 @@ worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as direct insert statement.~n", []),
-	io:format("**********************************************~n", []),
+	ct:log("Worker: write liststring as direct insert statement.~n", []),
+	ct:log("**********************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
 
-	io:format("Binary: ~p = ~w.~n", [Binary,Binary]),
+	ct:log("Binary: ~p = ~w.~n", [Binary,Binary]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -743,18 +743,18 @@ worker_direct_insert(Value, Binary) when is_list(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as parameter to prepared insert statement.~n", []),
-	io:format("*********************************************************~n", []),
+	ct:log("Worker: write binary as parameter to prepared insert statement.~n", []),
+	ct:log("*********************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Expect),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Expect),
 
@@ -764,18 +764,18 @@ worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as parameter to prepared insert statement.~n", []),
-	io:format("*************************************************************~n", []),
+	ct:log("Worker: write liststring as parameter to prepared insert statement.~n", []),
+	ct:log("*************************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Binary),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Binary),
 
@@ -969,7 +969,7 @@ test_unicode_quote_and_trailing_text_as_liststring(_) ->
 worker_insert_as_latin1_binary(V) ->
 
 	Value = list_to_binary(V),
-	io:format("~w~n", [list_to_binary(truncate(V))]),
+	ct:log("~w~n", [list_to_binary(truncate(V))]),
 	worker_direct_insert(Value, latin1, list_to_binary(truncate(V))),
 
     try 

--- a/test/utf8_to_latindb_SUITE.erl
+++ b/test/utf8_to_latindb_SUITE.erl
@@ -449,13 +449,13 @@ insert_and_read_back_as_recs(_) ->
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -478,13 +478,13 @@ select_by_prepared_statement(_) ->
 	Result = emysql:execute(test_pool, test_stmt, ["Hello%"]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record,<<"Hello World!">>}],
@@ -492,7 +492,7 @@ select_by_prepared_statement(_) ->
 	[{hello_record,BinString}] = Recs,
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result String (latin-1 string): ~ts~n", [BinString]),
+	ct:log("Result String (latin-1 string): ~ts~n", [BinString]),
 
 	% the test
 	BinString = <<"Hello World!">>,
@@ -517,24 +517,24 @@ read_back_directly(Value) when is_list(Value) ->
 read_back_directly(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
-	% io:format("                           expecting (unicode): ~ts~n", [Value]),
-	io:format("                           expecting (integer): ~w~n", [Value]),
+	ct:log("Read Back executing SELECT directly, expecting: ~p~n", [Value]),
+	% ct:log("                           expecting (unicode): ~ts~n", [Value]),
+	ct:log("                           expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, <<"SELECT * from hello_table">>),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record, ResultBin}] = Recs,
-   	io:format("Result String: ~w~n", [ResultBin]),
+   	ct:log("Result String: ~w~n", [ResultBin]),
 
 	% the test
  	Value = ResultBin,
@@ -552,20 +552,20 @@ read_back_by_statement(Value) when is_list(Value) ->
 read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
+	ct:log("Read Back using SELECT through prepared statement, expecting: ~p~n", [Value]),
 	
-	io:format("                                        expecting (integer): ~w~n", [Value]),
+	ct:log("                                        expecting (integer): ~w~n", [Value]),
 
 	Result = emysql:execute(test_pool, stmt_select),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Result: ~p~n", [Result]),
+	ct:log("Result: ~p~n", [Result]),
 
 	Recs = emysql_util:as_record(
 		Result, hello_record, record_info(fields, hello_record)),
 
 	% find this output by clicking on the test name, then case name in test/index.html
-	io:format("Recs: ~p~n", [Recs]),
+	ct:log("Recs: ~p~n", [Recs]),
 
 	% the test
 	Recs = [{hello_record, Value}],
@@ -573,7 +573,7 @@ read_back_by_statement(Value) when is_binary(Value) ->
 
 	% find this output by clicking on the test name, then case name in test/index.html
 	[{hello_record,BinString}] = Recs,
-	io:format("Result String: ~w~n", [BinString]),
+	ct:log("Result String: ~w~n", [BinString]),
 
 	% the test
 	BinString = Value,
@@ -697,15 +697,15 @@ test_latin1_liststring_via_parameter(_) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
-	io:format("******************************************~n", []),
+	ct:log("Worker: write binary as direct insert statement: ~p = ~w. (Exp: ~w)~n", [Value,Value,Expect]),
+	ct:log("******************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value,QuoteEncoding),emysql_util:quote(Value,QuoteEncoding)]),
 
 	X = emysql_util:any_to_binary(["INSERT INTO hello_table SET hello_text = ",
 			emysql_util:quote(Value,QuoteEncoding)]),
 
-	io:format("=> ~p = ~w.~n", [X,X]),
+	ct:log("=> ~p = ~w.~n", [X,X]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -722,12 +722,12 @@ worker_direct_insert(Value, QuoteEncoding, Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_direct_insert(Value, Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as direct insert statement.~n", []),
-	io:format("**********************************************~n", []),
+	ct:log("Worker: write liststring as direct insert statement.~n", []),
+	ct:log("**********************************************~n", []),
 
-	io:format("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
+	ct:log("                                  quote() makes: ~p = ~w.~n", [emysql_util:quote(Value),emysql_util:quote(Value)]),
 
-	io:format("Binary: ~p = ~w.~n", [Binary,Binary]),
+	ct:log("Binary: ~p = ~w.~n", [Binary,Binary]),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
@@ -744,18 +744,18 @@ worker_direct_insert(Value, Binary) when is_list(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 
-	io:format("Worker: write binary as parameter to prepared insert statement.~n", []),
-	io:format("*********************************************************~n", []),
+	ct:log("Worker: write binary as parameter to prepared insert statement.~n", []),
+	ct:log("*********************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Expect),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Expect),
 
@@ -765,18 +765,18 @@ worker_insert_via_statement(Value,_,Expect) when is_binary(Value) ->
 %%--------------------------------------------------------------------
 worker_insert_via_statement(Value,Binary) when is_list(Value) ->
 
-	io:format("Worker: write liststring as parameter to prepared insert statement.~n", []),
-	io:format("*************************************************************~n", []),
+	ct:log("Worker: write liststring as parameter to prepared insert statement.~n", []),
+	ct:log("*************************************************************~n", []),
 
     emysql:execute(test_pool, <<"DELETE FROM hello_table">>),
 
 	emysql:execute(test_pool, stmt_insert, [Value]),
 
-	io:format("... read back directly~n", []),
+	ct:log("... read back directly~n", []),
 
 	read_back_directly(Binary),
 
-	io:format("... read back via statement~n", []),
+	ct:log("... read back via statement~n", []),
 
 	read_back_by_statement(Binary),
 
@@ -970,7 +970,7 @@ test_unicode_quote_and_trailing_text_as_liststring(_) ->
 worker_insert_as_latin1_binary(V) ->
 
 	Value = list_to_binary(V),
-	io:format("~w~n", [list_to_binary(castrate(V))]),
+	ct:log("~w~n", [list_to_binary(castrate(V))]),
 	worker_direct_insert(Value, latin1, list_to_binary(castrate(V))),
 
     try 


### PR DESCRIPTION
This patch, which is an extension of the other one for now, but can be rebased later on, rips out all of the encoding stuff from the implementation. Thus, a binary is supposed to be pre-encoded by someone earlier in the call chain.

Currently, the implementation is more or less faithful to the original one. A change I would really like to see is to regard a list as an `iolist()` type and call iolist_to_binary on it. That way, any string-like object would be represented as an iolist. Even more complex would be to have the quote functions operate on iolists. So we could eliminate iolist_to_binary completely and just shove the iolist onwards to the socket. This would be even faster and more idiomatic to Erlang.

The patch has not seen much testing yet, but the plan is to test the branch shortly on some local in-house code here.
