### PR TITLE
Return an error_packet if a prepared statement is given an error.

### DIFF
--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -236,6 +236,8 @@ close_connection(Conn) ->
 %%--------------------------------------------------------------------
 set_params(_, _, [], Result) -> Result;
 set_params(_, _, _, Error) when is_record(Error, error_packet) -> Error;
+set_params(_, _, [error|_], _) ->
+	#error_packet{code=-1, msg="SQL parameter is error"};
 set_params(Connection, Num, Values, _) ->
 	Packet = set_params_packet(Num, Values, Connection#emysql_connection.encoding),
 	emysql_tcp:send_and_recv_packet(Connection#emysql_connection.socket, Packet, 0).


### PR DESCRIPTION
If a prepared statement is given the error atom as an argument then
don't send it to the server, but shortcut and return an #error_packet{}
instead.

This makes it easier to debug the problem, and avoids sending garbage to
the server.
