### PR TITLE
Use an unambiguous string to represent datetimes.

### DIFF
--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -236,7 +236,8 @@ encode({time, Val}, ReturnType, Encoding) ->
     encode(Val, ReturnType, Encoding);
 
 encode({{Year, Month, Day}, {Hour, Minute, Second}}, list, _) ->
-    Res = two_digits([Year, Month, Day, Hour, Minute, Second]),
+    Res = io_lib:format("'~4.4.0w-~2.2.0w-~2.2.0w ~2.2.0w:~2.2.0w:~2.2.0w'",
+                        [Year, Month, Day, Hour, Minute, Second]),
     lists:flatten(Res);
 
 encode({{_Year, _Month, _Day}, {_Hour, _Minute, _Second}}=Val, binary, E) ->


### PR DESCRIPTION
This sends a datetime to MySQL as 'YYYY-MM-DD hh:mm:ss' instead of the
numeric YYYYMMDDhhmmss.

This avoids problems when using small dates, such as year 1.  In that case
the previous code was sending 01 as the year part, which MySQL parses as
2001, not 1.

The accepted formats are documented at
http://dev.mysql.com/doc/refman/5.7/en/date-and-time-literals.html.
Maybe one day MySQL will support ISO 8601 _sigh_
