### PR TITLE
emysql:execute_many/2,3

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ For the exact spec, see below, [Usage][]. Regarding the 'pool', also see below.
 	
 	emysql:execute(my_pool, <<"call my_sp();">>).
 
+### Executing multiple queries in the same connection
+
+	emysql:execute_many(my_pool, [
+          <<"UPDATE mytable SET bar='baz'">>
+          <<"SELECT ROW_COUNT()">>
+      ]).
+
+This is needed when a query leaves some state behind, which can be retrieved
+only by a second query in the same connection.
+
+Prepared statements are also supported:
+
+	emysql:prepare(my_stmt, <<"UPDATE mytable SET bar='baz' WHERE id = ?">>).
+	emysql:execute_many(my_pool, [
+          {my_stmt, [1]}
+          <<"SELECT ROW_COUNT()">>
+      ]).
+
 ### Result Record
 
 	-record(result_packet, {seq_num, field_list, rows, extra}).


### PR DESCRIPTION
Ability to execute a few queries, in order, in the same connection.
Useful for queries that leave some state behind:
- SELECT ROW_COUNT()  (MySQL)
- LAST_INSERT_ID()  (MySQL)
- SHOW META  (Sphinx)
- etc

Jesper, if you are curious why this is here, this is my holiday homework. ;-)
