### PR TITLE
Changes for empty result sets

### DIFF
--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -59,7 +59,7 @@ as_dict(Res = #result_packet{}) ->
 as_proplist(#result_packet{field_list=_Cols,rows=_Vals}) when _Cols =:= undefined, 
 							      _Vals =:= undefined ->
     [];
-as_proplist(Res = #result_packet{field_list=_Cols,rows=_Vals}) when is_list(_Cols), 
+as_proplist(#result_packet{field_list=_Cols,rows=_Vals}) when is_list(_Cols), 
 								  _Vals =:= undefined ->
     [];
 as_proplist(Res = #result_packet{field_list=Cols,rows=Vals}) when is_list(Cols), 

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -1,6 +1,7 @@
 %% Copyright (c) 2009
 %% Bill Warnecke <bill@rupture.com>
 %% Jacob Vorreuter <jacob.vorreuter@gmail.com>
+%% Mike Oxford <moxford@gmail.com>
 %%
 %% Permission is hereby granted, free of charge, to any person
 %% obtaining a copy of this software and associated documentation
@@ -58,11 +59,9 @@ as_dict(Res = #result_packet{}) ->
 as_proplist(#result_packet{field_list=_Cols,rows=_Vals}) when _Cols =:= undefined, 
 							      _Vals =:= undefined ->
     [];
-as_proplist(Res = #result_packet{field_list=Cols,rows=Vals}) when is_list(Cols), 
-								  Vals =:= undefined ->
-    FieldData = emysql_util:field_names(Res),
-    RowData =  array:to_list(array:new([erlang:length(FieldData)])),
-    emysql_util:dualmap(fun(A,B)->{A,B} end, FieldData, RowData);
+as_proplist(Res = #result_packet{field_list=_Cols,rows=_Vals}) when is_list(_Cols), 
+								  _Vals =:= undefined ->
+    [];
 as_proplist(Res = #result_packet{field_list=Cols,rows=Vals}) when is_list(Cols), 
 								  is_list(Vals) ->
     FieldData = emysql_util:field_names(Res),

--- a/src/emysql_util.erl
+++ b/src/emysql_util.erl
@@ -62,6 +62,9 @@ as_proplist(#result_packet{field_list=_Cols,rows=_Vals}) when _Cols =:= undefine
 as_proplist(#result_packet{field_list=_Cols,rows=_Vals}) when is_list(_Cols), 
 								  _Vals =:= undefined ->
     [];
+as_proplist(#result_packet{field_list=_Cols,rows=_Vals}) when is_list(_Cols), 
+								  _Vals =:= [] ->
+    [];
 as_proplist(Res = #result_packet{field_list=Cols,rows=Vals}) when is_list(Cols), 
 								  is_list(Vals) ->
     FieldData = emysql_util:field_names(Res),

--- a/test/emysql_util_SUITE.erl
+++ b/test/emysql_util_SUITE.erl
@@ -63,7 +63,7 @@ end_per_suite(_) ->
 %% Test Cases: Test if emysql_util:as_dict/1 works
 %%--------------------------------------------------------------------
 dict_empty_test(_) ->
-    dict:from_list([{<<"HelloField">>,undefined}]) =:= emysql_util:as_dict(get_empty_test()).
+    dict:from_list([]) =:= emysql_util:as_dict(get_empty_test()).
 
 dict_single_test(_) ->
     dict:from_list([{<<"HelloField">>,<<"Hello">>}]) =:= emysql_util:as_dict(get_single_test()).
@@ -78,7 +78,7 @@ dict_multi_test(_) ->
 %% Test Cases: Test if emysql_util:as_proplist/1 works
 %%--------------------------------------------------------------------
 proplist_empty_test(_) ->
-    [{<<"HelloField">>,undefined}] =:= emysql_util:as_proplist(get_empty_test()).
+    [] =:= emysql_util:as_proplist(get_empty_test()).
 
 proplist_single_test(_) ->
     [{<<"HelloField">>,<<"Hello">>}] =:=  emysql_util:as_proplist(get_single_test()).


### PR DESCRIPTION
It will now give "zero results via empty list" instead of padding with values of 'undefined' for the case of "no matches."  

Tests updated as well.
