### PR TITLE
Propagate connection initialization problems

### DIFF
--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -135,7 +135,15 @@ do_gen_call(Msg) ->
 %%--------------------------------------------------------------------
 init([]) ->
     Pools = initialize_pools(),
-    Pools1 = [emysql_conn:open_connections(Pool) || Pool <- Pools],
+    Pools1 = lists:map(
+        fun (Pool) ->
+                case emysql_conn:open_connections(Pool) of
+                    {ok, Pool} -> Pool;
+                    {error, Reason} -> throw(Reason)
+                end
+        end,
+        Pools
+    ),
     {ok, #state{pools=Pools1}}.
 
 %%--------------------------------------------------------------------

--- a/test/environment_SUITE.erl
+++ b/test/environment_SUITE.erl
@@ -160,7 +160,7 @@ add_pool_wrong_db(_) ->
         end
     ),
     receive
-        {'DOWN', Mref, process, Pid, {failed_to_set_database, _}} ->
+        {'DOWN', Mref, process, Pid, {{nocatch, {failed_to_set_database, _}}, _}} ->
             ok
     after 100 ->
             exit(should_have_failed)
@@ -176,7 +176,7 @@ add_pool_wrong_cmd(_) ->
         end
     ),
     receive
-        {'DOWN', Mref, process, Pid, {failed_to_run_cmd, _}} ->
+        {'DOWN', Mref, process, Pid, {{nocatch, {failed_to_run_cmd, _}}, _}} ->
             ok
     after 100 ->
             exit(should_have_failed)


### PR DESCRIPTION
When connection failed to open, it used to not tell it to the caller.
With this patch it propagates the error to the caller (like it used to
be in 0.2), and closes the orphaned connections (which is a new
feature).

This patch also makes basic tests pass again.
