### PR TITLE
Prevent the conn mgr from locking out the db if a client dies

### DIFF
--- a/include/emysql.hrl
+++ b/include/emysql.hrl
@@ -27,7 +27,7 @@
 
 
 -record(pool, {pool_id, size, user, password, host, port, database, encoding, available=queue:new(), locked=gb_trees:empty(), waiting=queue:new(), start_cmds=[], conn_test_period=0}).
--record(emysql_connection, {id, pool_id, encoding, socket, version, thread_id, caps, language, prepared=gb_trees:empty(), locked_at, alive=true, test_period=0, last_test_time=0}).
+-record(emysql_connection, {id, pool_id, encoding, socket, version, thread_id, caps, language, prepared=gb_trees:empty(), locked_at, alive=true, test_period=0, last_test_time=0, monitor_ref}).
 -record(greeting, {protocol_version, server_version, thread_id, salt1, salt2, caps, caps_high, language, status, seq_num, plugin}).
 -record(field, {seq_num, catalog, db, table, org_table, name, org_name, type, default, charset_nr, length, flags, decimals}).
 -record(packet, {size, seq_num, data}).


### PR DESCRIPTION
This is the fix for: https://github.com/Eonblast/Emysql/issues/93

Whenever a connection is locked for a specific pid, emysql_conn_mgr monitors that pid. If the client dies, the connection is reset (I considered just returning it to the pool, it may be in the middle of returning data from MySQL, may it be not).

Note this is based on commit eff612d72b3f808ef6688c72bf69905c85ca02fd
