### PR TITLE
Fixed initial accumulator bug in open_n_connections.

### DIFF
--- a/src/emysql_conn.erl
+++ b/src/emysql_conn.erl
@@ -124,7 +124,7 @@ open_n_connections(PoolId, N) ->
                     {'EXIT', Reason} ->
                         {Conns, [Reason | Reasons]}
                 end
-            end, [], lists:seq(1, N));
+            end, {[], []}, lists:seq(1, N));
         _ ->
             exit(pool_not_found)
     end.


### PR DESCRIPTION
Fixed a bug which made `emysql:increment_pool_size/1` unusable.

The `foldl` initial accumulator in `emysql_conn:open_n_connections/2` was an empty list and could not match the pattern in the fold fun which expected a two element tuple accumulator.
