### PR TITLE
Fixed cast bug for NULL table entries.

### DIFF
--- a/src/emysql_tcp.erl
+++ b/src/emysql_tcp.erl
@@ -365,9 +365,8 @@ to_timestamp(Data) ->
 to_bit(<<1>>) -> 1;  %%TODO: is this right?.  Shouldn't be <<"1">> ?
 to_bit(<<0>>) -> 0.
 
-
-type_cast_row_data(Data, #field{decoder = F}) ->
-    F(Data).
+type_cast_row_data(undefined, _) -> undefined;
+type_cast_row_data(Data, #field{decoder = F}) -> F(Data).
 
 
 


### PR DESCRIPTION
Exception was being thrown when attempting to decode NULL fields (as `undefined`).

Added pattern to bypass decoder functions when field is `undefined`.
