### PR TITLE
crypto:sha/crypto:hash backwards compatibility and small fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/variables-ct*
 test/ct_default.css
 logs/*
 .#*
+include/crypto_compat.hrl

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,13 @@ CRYPTO_PATH=/opt/local/var/macports/software/erlang/R14A_0/opt/local/lib/erlang/
 MODULES=$(shell ls -1 src/*.erl | awk -F[/.] '{ print $$2 }' | sed '$$q;s/$$/,/g')
 MAKETIME=$(shell date)
 
-all: app
+all: crypto_compat app
 	(cd src;$(MAKE))
 
 app: ebin/$(PKGNAME).app
+
+crypto_compat:
+	(escript support/crypto_compat.escript)
 
 ebin/$(PKGNAME).app: src/$(PKGNAME).app.src
 	mkdir -p ebin
@@ -55,6 +58,7 @@ clean:
 	rm -f variables-ct*
 	rm -f *.beam
 	rm -f *.html
+	rm -f include/crypto_compat.hrl
 
 package: clean
 	@mkdir $(PKGNAME)-$(VERSION)/ && cp -rf ebin include Makefile README src support t $(PKGNAME)-$(VERSION)

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,6 @@
+% -*- Erlang -*-
+% vim: ts=4 sw=4 et ft=erlang
+{pre_hooks,[
+        {"linux|bsd|darwin|solaris", compile, "escript ./support/crypto_compat.escript"},
+        {"win32", compile, "escript.exe support/crypto_compat.escript"}
+]}.

--- a/support/crypto_compat.escript
+++ b/support/crypto_compat.escript
@@ -1,0 +1,49 @@
+#!/usr/bin/env escript
+%% vim: ts=4 sw=4 et ft=erlang
+
+%% The purpose of this script is to analyze the capabilities of the ERTS to
+%% determine if it supports crypto:hash and its sibling functions. Erlang from
+%% R15B to R16B01 underwent a handful of non-backwards compatible changes to
+%% the crypto module, and in R16B, started emitting errors about the use of
+%% crypto:sha. This script will adjust accordingly to support older versions of
+%% Erlang without headache.
+%%
+%% Note: This should be run *before* compiling!
+
+main([]) ->
+    crypto:start(),
+
+	Filename = "include/crypto_compat.hrl",
+	io:format("Generating ~p ...~n", [Filename]),
+
+	case erlang:function_exported(crypto, hash, 2) of
+        true ->
+            HASH_SHA = "crypto:hash(sha, Data)",
+            HASH_FINAL = "crypto:hash_final(Data)",
+            HASH_UPDATE = "crypto:hash_update(Data, Salt)",
+            HASH_INIT = "crypto:hash_init(sha)",
+            io:format("...supports cryto:hash/2~n");
+        false ->
+            HASH_SHA = "crypto:sha(Data)",
+            HASH_FINAL = "crypto:sha_final(Data)",
+            HASH_UPDATE = "crypto:sha_update(Data, Salt)",
+            HASH_INIT = "crypto:sha_init()",
+            io:format("...does not support crypto:hash/2. Using crypto:sha/1~n")
+    end,
+
+	Contents = [
+        "%% Note: This file was automatically generated. Do not include it in source control\n",
+		"-define(HASH_SHA(Data), ",         HASH_SHA,").\n",
+		"-define(HASH_FINAL(Data), ",       HASH_FINAL,").\n",
+		"-define(HASH_UPDATE(Data, Salt), ",HASH_UPDATE,").\n",
+        "-define(HASH_INIT(), ",            HASH_INIT,").\n"
+	],
+
+    ContentsBin = iolist_to_binary(Contents),
+    case file:read_file(Filename) of
+        {ok, ContentsBin} -> 
+            io:format("...no changes needed to ~p. Skipping writing new file~n", [Filename]);
+        _ -> 
+            io:format("...writing ~p~n", [Filename]),
+            file:write_file(Filename, Contents)
+    end.


### PR DESCRIPTION
As a followup to PR https://github.com/Eonblast/Emysql/pull/104, I've made proposed changes that dynamically generate the crypto:sha or crypto:hash functions based on the Capabilities of the installed Erlang system.

From one of the git commit comments:

Relevant changes:

```
.gitignore: Made so the autogenerated crypto_compat.hrl file is not
included in source control. It should be ignored because of its
autogenerated nature

Makefile: Add `make crypto_compat` rule, and make sure it runs before
compiling the modules.

rebar.config: Added so that apps that use rebar for dependencies can
take advantage of Rebar's pre_hooks capability

emysql_auth: Modified the password generation to use the generated
Macros instead of straight calls.

support/crypto_compat.escript: The script that generates the
include/crypto_compat.hrl file.
```

Also this includes a small "can never match" fix that dialyzer found.
