### PR TITLE
More Dialyzer

### DIFF
--- a/include/emysql.hrl
+++ b/include/emysql.hrl
@@ -33,7 +33,7 @@
 	       host :: list(), 
 	       port :: number(), 
 	       database :: list(), 
-	       encoding :: atom(), 
+	       encoding :: utf8 | latin1 | {utf8, utf8_unicode_ci} | {utf8, utf8_general_ci},
 	       available=queue:new() :: queue(), 
 	       locked=gb_trees:empty() :: gb_tree(), 
 	       waiting=queue:new() :: queue(), 

--- a/include/emysql.hrl
+++ b/include/emysql.hrl
@@ -56,8 +56,32 @@
 			    last_test_time=0 :: number(), 
 			    monitor_ref :: reference()}).
 
--record(greeting, {protocol_version, server_version, thread_id, salt1, salt2, caps, caps_high, language, status, seq_num, plugin}).
--record(field, {seq_num, catalog, db, table, org_table, name, org_name, type, default, charset_nr, length, flags, decimals, decoder}).
+-record(greeting, {protocol_version :: number(), 
+                   server_version, 
+                   thread_id :: number(), 
+                   salt1 :: binary(), 
+                   salt2 :: binary(), 
+                   caps :: number(), 
+                   caps_high :: number(), 
+                   language :: number(), 
+                   status :: number(), 
+                   seq_num :: number(), 
+                   plugin :: binary()}).
+
+-record(field, {seq_num, 
+                catalog, 
+                db , 
+                table , 
+                org_table, 
+                name , 
+                org_name, 
+                type, 
+                default, 
+                charset_nr, 
+                length, 
+                flags, 
+                decimals, 
+                decoder}).
 -record(packet, {size :: number(), 
 		 seq_num :: number(), 
 		 data :: binary()}).

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -243,7 +243,9 @@ config_ok(#pool{pool_id=PoolId,size=Size,user=User,password=Password,host=Host,p
 config_ok(_BadOptions) ->
     erlang:error(badarg).
 
-encoding_ok(Enc) when is_atom(Enc) -> ok.
+encoding_ok(Enc) when is_atom(Enc) ->  ok; 
+encoding_ok({Enc, Coll}) when is_atom(Enc), is_atom(Coll) -> ok; 
+encoding_ok(_)  ->  erlang:error(badarg).
 
 %% Creates a pool record, opens n=Size connections and calls
 %% emysql_conn_mgr:add_pool() to make the pool known to the pool management.

--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -243,9 +243,7 @@ config_ok(#pool{pool_id=PoolId,size=Size,user=User,password=Password,host=Host,p
 config_ok(_BadOptions) ->
     erlang:error(badarg).
 
-encoding_ok(Enc) when is_atom(Enc) -> ok;
-encoding_ok({Enc, Coll}) when is_atom(Enc), is_atom(Coll) -> ok;
-encoding_ok(_)  -> erlang:error(badarg).
+encoding_ok(Enc) when is_atom(Enc) -> ok.
 
 %% Creates a pool record, opens n=Size connections and calls
 %% emysql_conn_mgr:add_pool() to make the pool known to the pool management.


### PR DESCRIPTION
1. Added types for (most of) the greeting record.
2. In dj_al's commit, there was a check the encoding, but running dialyzer shows that the encoding can only ever be an atom, so the other checks in the pattern match were superfluous. I made the simplest change to get dialyzer passing again, but now the encoding_ok check seems superfluous (again, because the encoding field has to be an atom for dialyzer to pass). Should `make dialyzer` be added to the travis build?
