### PR TITLE
Bugfix: Do not remove others pools when removing all connections in a pool

### DIFF
--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -204,7 +204,7 @@ handle_call({remove_connections, PoolId, Num}, _From, State) ->
         {Pool, OtherPools} ->
             case Num > queue:len(Pool#pool.available) of
                 true ->
-                    State1 = State#state{pools = [Pool#pool{available = queue:new()}]},
+                    State1 = State#state{pools = [Pool#pool{available = queue:new()}|OtherPools]},
                     {reply, queue:to_list(Pool#pool.available), State1};
                 false ->
                     {Conns, OtherConns} = queue:split(Num, Pool#pool.available),


### PR DESCRIPTION
Trying to emysql:decrement_pool_size/2 on a pool with a higher number of connection that available connections for that would remove all other pools as well, this pull request fixes that.
