### PR TITLE
Update emysql.erl

### DIFF
--- a/src/emysql.erl
+++ b/src/emysql.erl
@@ -669,7 +669,7 @@ result_type(#eof_packet{})    -> eof.
 -spec as_dict(Result) -> Dict
   when
     Result :: #result_packet{},
-    Dict :: dict().
+    Dict :: dict:dict().
 as_dict(Res) -> emysql_conv:as_dict(Res).
 
 


### PR DESCRIPTION
Type dict/0 is deprecated and will be removed in OTP 18.0. Should be used dict:dict/0 or preferably dict:dict/2
