### PR TITLE
Adds transaction and "with connection" and kills monitor_work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ CT_RUN = ct_run \
         -cover test/cover.spec -cover_stop false \
         $(CT_OPTS)
 # Currently, the order of the test cases matter!
-CT_SUITES=environment basics conn_mgr with_connection
+CT_SUITES=environment basics conn_mgr with_connection transaction
 
 build-tests:
 	erlc -v -o test/ $(wildcard test/*.erl) -pa ebin/

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ CT_RUN = ct_run \
         -cover test/cover.spec -cover_stop false \
         $(CT_OPTS)
 # Currently, the order of the test cases matter!
-CT_SUITES=environment basics conn_mgr
+CT_SUITES=environment basics conn_mgr with_connection
 
 build-tests:
 	erlc -v -o test/ $(wildcard test/*.erl) -pa ebin/

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If you are looking for the **plain necessities**, you should use the [ejabberd][
 
 #### Transaction
 
-This driver has a recently got support for transactions. See [Transactions] under the Samples section below.
+This driver has a recently got experimental support for transactions. See the Samples section below.
 
 ## Samples                                             <a name=Samples></a>
 

--- a/test/transaction_SUITE.erl
+++ b/test/transaction_SUITE.erl
@@ -1,0 +1,60 @@
+-module(transaction_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("../include/emysql.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2,
+         successful_transaction/1, failing_transaction/1]).
+
+-define(pool_name, ?MODULE).
+
+all() -> 
+    [successful_transaction, failing_transaction].
+
+init_per_suite(Config) ->
+    crypto:start(),
+    application:start(emysql),
+    emysql:add_pool(?pool_name, [
+        {size, 1},
+        {user, test_helper:test_u()},
+        {password, test_helper:test_p()},
+        {host, "localhost"},
+        {port, 3306},
+        {database, "hello_database"},
+        {encoding, utf8},
+        {warnings, true}]),
+    Config.
+
+end_per_suite(_Config) ->
+	emysql:remove_pool(?pool_name),
+	ok.
+
+init_per_testcase(_TestCase, Config) ->
+    emysql:execute(?pool_name, <<"CREATE TABLE transaction_test (foo INT) ENGINE=InnoDB">>),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    emysql:execute(?pool_name, <<"DROP TABLE transaction_test">>),
+    ok.
+
+successful_transaction(_Config) ->
+    emysql:transaction(?pool_name, fun (Connection) ->
+        emysql_conn:execute(Connection, <<"INSERT INTO transaction_test (foo) VALUES (42)">>, []),
+        emysql_conn:execute(Connection, <<"INSERT INTO transaction_test (foo) VALUES (43)">>, [])
+    end),
+    %% Check that these rows were inserted.
+    #result_packet{rows = [[42], [43]]} =
+        emysql:execute(?pool_name, <<"SELECT foo FROM transaction_test ORDER BY foo">>),
+    ok.
+
+failing_transaction(_Config) ->
+    catch emysql:transaction(?pool_name, fun (Connection) ->
+        emysql_conn:execute(Connection, <<"INSERT INTO transaction_test (foo) VALUES (42)">>, []),
+        emysql_conn:execute(Connection, <<"INSERT INTO transaction_test (foo) VALUES (43)">>, []),
+        error(foo)
+    end),
+    %% Check that no rows were inserted.
+    Result = emysql:execute(?pool_name, <<"SELECT foo FROM transaction_test">>),
+    #result_packet{rows = []} = Result,
+    ok.

--- a/test/with_connection_SUITE.erl
+++ b/test/with_connection_SUITE.erl
@@ -1,0 +1,115 @@
+-module(with_connection_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("../include/emysql.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         concurrent_connections/1, error_in_job/1]).
+
+-define(pool_name, ?MODULE).
+-define(pool_size, 2).
+
+all() -> 
+    [concurrent_connections, error_in_job].
+
+init_per_suite(Config) ->
+    crypto:start(),
+    application:start(emysql),
+    emysql:add_pool(?pool_name, [
+        {size, ?pool_size},
+        {user, test_helper:test_u()},
+        {password, test_helper:test_p()},
+        {host, "localhost"},
+        {port, 3306},
+        {database, "hello_database"},
+        {encoding, utf8},
+        {warnings, true}]),
+    Config.
+
+end_per_suite(_Config) ->
+	emysql:remove_pool(?pool_name),
+	ok.
+
+%% Work on two different connections simultaneously. We set a variable, then
+%% fetch it again.
+%%--------------------------------------------------------------------
+concurrent_connections(_Config) ->
+    % Clean-up before, just in case (looks like bad practice)
+    %catch emysql:remove_pool(pool1) end,
+
+    ParentPid = self(),
+
+    %% Assert that all connections are available before we start.
+    ?pool_size = num_available_connections(),
+
+    %% Start two jobs that set a variable and fetches the variable again in a connection.
+    %% Syncronizes with the main process a few times.
+    Pid1 = spawn_link(fun () ->
+        emysql:with_connection(?pool_name, fun (Connection) ->
+            ParentPid ! {job1, started},
+            #ok_packet{} = emysql_conn:execute(Connection, <<"SET @foo = 42">>, []),
+            receive continue -> ok end,
+            #result_packet{rows = [[42]]} =
+                emysql_conn:execute(Connection, <<"SELECT @foo">>, [])
+        end),
+        ParentPid ! {job1, done}
+    end),
+    Pid2 = spawn_link(fun () ->
+        emysql:with_connection(?pool_name, fun (Connection) ->
+            ParentPid ! {job2, started},
+            #ok_packet{} = emysql_conn:execute(Connection, <<"SET @foo = 'bar'">>, []),
+            receive continue -> ok end,
+            #result_packet{rows = [[<<"bar">>]]} =
+                emysql_conn:execute(Connection, <<"SELECT @foo">>, [])
+        end),
+        ParentPid ! {job2, done}
+    end),
+
+    %% Wait for them to start.
+    receive {job1, started} -> ok end,
+    receive {job2, started} -> ok end,
+
+    %% Assert that we have 2 fewer connections available in the pool.
+    ?pool_size = num_available_connections() + 2,
+
+    %% Tell them to continue and finish the work.
+    Pid1 ! continue,
+    Pid2 ! continue,
+
+    %% Wait for them to finish
+    receive {job1, done} -> ok end,
+    receive {job2, done} -> ok end,
+
+    %% Assert that all connections are back in the pool again.
+    ?pool_size = num_available_connections(),
+
+    ok.
+
+%% Make sure the number of available connections in the pool is unaffected by an error in
+%% a job.
+error_in_job(_Config) ->
+    %% Assert that all connections are available before we start.
+    ?pool_size = num_available_connections(),
+
+    try
+        emysql:with_connection(
+            ?pool_name,
+            fun (_Connection) ->
+                throw(foo)
+            end
+        ),
+        error(never_reached)
+    catch
+        throw:foo -> ok
+    end,
+
+    %% Assert that all connections are back in the pool again.
+    ?pool_size = num_available_connections(),
+
+    ok.
+
+%% --- Internal ---
+
+%% Returns the number of available connections in our pool. Used in the tests.
+num_available_connections() ->
+    {Pool, _} = emysql_conn_mgr:find_pool(?pool_name, emysql_conn_mgr:pools()),
+    queue:len(Pool#pool.available).


### PR DESCRIPTION
I have made some changes and added transactions as a proposed solution to #23.

Background: I'm working on a project porting parts of a PHP system to Erlang and facts are we need MySQL and transactions. In our first attempt, we added a way to pass a fun to monitor_work, but that was not nice for two reasons: 1. monitor_work kills all the error messages and traces within our transactions, since it does stuff in its own process, and 2. monitor_work kills our transactions after a certain time. This is not very nice design. We need the timeout per query, not per transaction.

So, here is my second attempt. This pull request contains the following:
- Replaces monitor_work with a try-catch, where we simply catch all exceptions and reset the connection if any uncaught errors occur. Then the same error is re-raised with the same stacktrace using erlang:raise/3. (This is also how poolboy does it.).
- Adds a versions of emysql_conn:execute that accept a Timeout parameter. This is also added to emysql_tcp:send_and_recv_packet. Timeouts are now handled in emysql_conn:execute instead of in emysql:execute. (I'm not sure exactly how the timeout is used though, but it is passed on to emysql_tcp.)
- New function: emysql:with_connection/2,3 that takes a fun that is applied to a connection from a pool. This is sometimes useful to do without doing an actual SQL transaction. (See comments in the README.)
- New function: emysql:transaction/2,3 that uses with_connection but does BEGIN, COMMIT and ROLLBACK as required.
- Replaces some old `@spec` with `-spec` and adjusts some documentation for the changed implementation of emysql:execute/2,3,4,5.
- Test suites for with_connection and transaction.
