### PR TITLE
fix - 'asciiz/1' function of 'emysql_auth' module was fixed

### DIFF
--- a/src/emysql_auth.erl
+++ b/src/emysql_auth.erl
@@ -200,5 +200,7 @@ hash([], N1, N2, _Add) ->
     {N1 band Mask , N2 band Mask}.
 
 asciiz(Data) when is_binary(Data) ->
-    [S, R] = binary:split(Data, <<0>>),
-    {S, R}.
+    case binary:split(Data, <<0>>) of
+        [S1, R] -> {S1, R};
+        [S2] -> {S2, <<>>}
+    end.


### PR DESCRIPTION
**'asciiz/1'  function of 'emysql_auth' module was fixed.**

https://github.com/Eonblast/Emysql/blob/c7e2103f8b737667f0128802e8de2f0d5ed2fa5c/src/emysql_auth.erl#L91
here `<<>>` expects as second returning value, but it will be never received since  `binary:split/2 ` function doesn`t complement returning value.

Example:

> 1> binary:split(<<1,2,3,4,5,6,7,8,9,10,11,12,13>>,<<0>>).
> [<<1,2,3,4,5,6,7,8,9,10,11,12,13>>]